### PR TITLE
Allow definition of custom actions

### DIFF
--- a/src/Cli/Command/InitCustomActionCommand.php
+++ b/src/Cli/Command/InitCustomActionCommand.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the Acme PHP project.
+ *
+ * (c) Titouan Galopin <galopintitouan@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace AcmePhp\Cli\Command;
+
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ */
+class InitCustomActionCommand extends AbstractCommand
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this->setName('init-custom-action')
+            ->setDefinition([
+                new InputArgument('name', InputArgument::REQUIRED, 'The custom action name (the name you will use in your configuration, the equivalent of push_ftp or build_nginxproxy)'),
+            ])
+            ->setDescription('Generate a demo custom post-generate action')
+            ->setHelp(<<<'EOF'
+The <info>%command.name%</info> command list will create a demo custom post-generate action in the <info>~/.acmephp/actions</info>
+directory. You will be able to edit the generated file in order to implement a specific behavior to deal with your certificates.
+EOF
+            );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+    }
+}


### PR DESCRIPTION
As specified in the current configuration file, it would be useful to be able to define custom post-generate actions to do specific stuff after the generation of the certificates. I propose the following:

* [ ] custom actions are stored in the `~/.acmephp/actions` as PHP classes suffixed by `Action`
* [ ] to find the custom actions to load, the PHAR iterates over the files in this directory filtering by suffix `Action.php` and loads them in the DI container
* [ ] a native command `init-custom-action <action-name>` allows anyone to easily start a demo action