### PR TITLE
remove the hashtag of slack channel name in the default config

### DIFF
--- a/res/acmephp.conf.dist
+++ b/res/acmephp.conf.dist
@@ -83,6 +83,6 @@ monitoring: ~   # Monitoring is disabled by default
 #
 #    slack:
 #        token: your_token
-#        channel: #general
+#        channel: general   # Channel name without hashtag
 #        # username: Acme PHP
 #        # level: info      # By default, on every CRON for slack handler


### PR DESCRIPTION
In YAML hashtag starts a comment. Removed hashtag of default channel
name and added comment that no hastag is needed.