### PR TITLE
Refactor file tree

### DIFF
--- a/src/Cli/Command/RequestCommand.php
+++ b/src/Cli/Command/RequestCommand.php
@@ -13,6 +13,7 @@ namespace AcmePhp\Cli\Command;
 
 use AcmePhp\Cli\ActionHandler\ActionHandler;
 use AcmePhp\Cli\Command\Helper\DistinguishedNameHelper;
+use AcmePhp\Cli\Repository\Repository;
 use AcmePhp\Cli\Repository\RepositoryInterface;
 use AcmePhp\Core\AcmeClientV2Interface;
 use AcmePhp\Ssl\CertificateRequest;
@@ -215,14 +216,14 @@ EOF;
 
         $replacements = [
             '%expiration%' => $parsedCertificate->getValidTo()->format(\DateTime::ISO8601),
-            '%private%' => $masterPath.'/private/'.$domain.'/private.pem',
-            '%combined%' => $masterPath.'/private/'.$domain.'/combined.pem',
-            '%cert%' => $masterPath.'/certs/'.$domain.'/cert.pem',
-            '%chain%' => $masterPath.'/certs/'.$domain.'/chain.pem',
-            '%fullchain%' => $masterPath.'/certs/'.$domain.'/fullchain.pem',
+            '%private%' => $masterPath.'/'.Repository::PATH_DOMAIN_KEY_PRIVATE,
+            '%combined%' => $masterPath.'/'.Repository::PATH_DOMAIN_CERT_COMBINED,
+            '%cert%' => $masterPath.'/'.Repository::PATH_DOMAIN_CERT_CERT,
+            '%chain%' => $masterPath.'/'.Repository::PATH_DOMAIN_CERT_CHAIN,
+            '%fullchain%' => $masterPath.'/'.Repository::PATH_DOMAIN_CERT_FULLCHAIN,
         ];
 
-        $this->info(str_replace(array_keys($replacements), array_values($replacements), $success));
+        $this->info(strtr(strtr($success, $replacements), ['{domain}' => $domain]));
     }
 
     /**

--- a/tests/Cli/AbstractApplicationTest.php
+++ b/tests/Cli/AbstractApplicationTest.php
@@ -65,8 +65,8 @@ abstract class AbstractApplicationTest extends AbstractFunctionnalTest
 
         $this->assertContains('No account key pair was found, generating one', $registerDisplay);
         $this->assertContains('Account registered successfully', $registerDisplay);
-        $this->assertFileExists(__DIR__.'/../Cli/Fixtures/local/master/private/_account/private.pem');
-        $this->assertFileExists(__DIR__.'/../Cli/Fixtures/local/master/private/_account/public.pem');
+        $this->assertFileExists(__DIR__.'/../Cli/Fixtures/local/master/account/key.private.pem');
+        $this->assertFileExists(__DIR__.'/../Cli/Fixtures/local/master/account/key.public.pem');
 
         /*
          * Authorize
@@ -83,7 +83,7 @@ abstract class AbstractApplicationTest extends AbstractFunctionnalTest
 
         $this->assertContains('The authorization tokens was successfully fetched', $authorizeDisplay);
         $this->assertContains('http://acmephp.com/.well-known/acme-challenge/', $authorizeDisplay);
-        $this->assertFileExists(__DIR__.'/../Cli/Fixtures/local/master/private/acmephp.com/authorization_challenge.json');
+        $this->assertFileExists(__DIR__.'/../Cli/Fixtures/local/master/var/acmephp.com/authorization_challenge.json');
 
         /*
          * Check
@@ -91,7 +91,7 @@ abstract class AbstractApplicationTest extends AbstractFunctionnalTest
 
         // Find challenge and expose token
         $challenge = json_decode(
-            file_get_contents(__DIR__.'/../Cli/Fixtures/local/master/private/acmephp.com/authorization_challenge.json'),
+            file_get_contents(__DIR__.'/../Cli/Fixtures/local/master/var/acmephp.com/authorization_challenge.json'),
             true
         );
 
@@ -138,12 +138,12 @@ abstract class AbstractApplicationTest extends AbstractFunctionnalTest
 
         $this->assertContains('The SSL certificate was fetched successfully', $requestDisplay);
         $this->assertContains(Path::canonicalize(__DIR__.'/Fixtures/local/master'), $requestDisplay);
-        $this->assertFileExists(__DIR__.'/../Cli/Fixtures/local/master/private/acmephp.com/private.pem');
-        $this->assertFileExists(__DIR__.'/../Cli/Fixtures/local/master/private/acmephp.com/public.pem');
-        $this->assertFileExists(__DIR__.'/../Cli/Fixtures/local/master/certs/acmephp.com/cert.pem');
-        $this->assertFileExists(__DIR__.'/../Cli/Fixtures/local/master/private/acmephp.com/combined.pem');
-        $this->assertFileExists(__DIR__.'/../Cli/Fixtures/local/master/certs/acmephp.com/chain.pem');
-        $this->assertFileExists(__DIR__.'/../Cli/Fixtures/local/master/certs/acmephp.com/fullchain.pem');
+        $this->assertFileExists(__DIR__.'/../Cli/Fixtures/local/master/certs/acmephp.com/private/key.private.pem');
+        $this->assertFileExists(__DIR__.'/../Cli/Fixtures/local/master/certs/acmephp.com/private/key.public.pem');
+        $this->assertFileExists(__DIR__.'/../Cli/Fixtures/local/master/certs/acmephp.com/public/cert.pem');
+        $this->assertFileExists(__DIR__.'/../Cli/Fixtures/local/master/certs/acmephp.com/private/combined.pem');
+        $this->assertFileExists(__DIR__.'/../Cli/Fixtures/local/master/certs/acmephp.com/public/chain.pem');
+        $this->assertFileExists(__DIR__.'/../Cli/Fixtures/local/master/certs/acmephp.com/public/fullchain.pem');
     }
 
     /**

--- a/tests/Cli/MonitoredApplicationTest.php
+++ b/tests/Cli/MonitoredApplicationTest.php
@@ -69,12 +69,12 @@ class MonitoredApplicationTest extends AbstractApplicationTest
             '--force' => true,
         ]);
 
-        $this->assertFileExists(__DIR__.'/../Cli/Fixtures/local/master/private/acmephp.com/private.pem');
-        $this->assertFileExists(__DIR__.'/../Cli/Fixtures/local/master/private/acmephp.com/public.pem');
-        $this->assertFileExists(__DIR__.'/../Cli/Fixtures/local/master/certs/acmephp.com/cert.pem');
-        $this->assertFileExists(__DIR__.'/../Cli/Fixtures/local/master/private/acmephp.com/combined.pem');
-        $this->assertFileExists(__DIR__.'/../Cli/Fixtures/local/master/certs/acmephp.com/chain.pem');
-        $this->assertFileExists(__DIR__.'/../Cli/Fixtures/local/master/certs/acmephp.com/fullchain.pem');
+        $this->assertFileExists(__DIR__.'/../Cli/Fixtures/local/master/certs/acmephp.com/private/key.private.pem');
+        $this->assertFileExists(__DIR__.'/../Cli/Fixtures/local/master/certs/acmephp.com/private/key.public.pem');
+        $this->assertFileExists(__DIR__.'/../Cli/Fixtures/local/master/certs/acmephp.com/public/cert.pem');
+        $this->assertFileExists(__DIR__.'/../Cli/Fixtures/local/master/certs/acmephp.com/private/combined.pem');
+        $this->assertFileExists(__DIR__.'/../Cli/Fixtures/local/master/certs/acmephp.com/public/chain.pem');
+        $this->assertFileExists(__DIR__.'/../Cli/Fixtures/local/master/certs/acmephp.com/public/fullchain.pem');
     }
 
     public function testRenewalWithIssue()
@@ -96,12 +96,12 @@ class MonitoredApplicationTest extends AbstractApplicationTest
             '--force' => true,
         ]);
 
-        $this->assertFileExists(__DIR__.'/../Cli/Fixtures/local/master/private/acmephp.com/private.pem');
-        $this->assertFileExists(__DIR__.'/../Cli/Fixtures/local/master/private/acmephp.com/public.pem');
-        $this->assertFileExists(__DIR__.'/../Cli/Fixtures/local/master/certs/acmephp.com/cert.pem');
-        $this->assertFileExists(__DIR__.'/../Cli/Fixtures/local/master/private/acmephp.com/combined.pem');
-        $this->assertFileExists(__DIR__.'/../Cli/Fixtures/local/master/certs/acmephp.com/chain.pem');
-        $this->assertFileExists(__DIR__.'/../Cli/Fixtures/local/master/certs/acmephp.com/fullchain.pem');
+        $this->assertFileExists(__DIR__.'/../Cli/Fixtures/local/master/certs/acmephp.com/private/key.private.pem');
+        $this->assertFileExists(__DIR__.'/../Cli/Fixtures/local/master/certs/acmephp.com/private/key.public.pem');
+        $this->assertFileExists(__DIR__.'/../Cli/Fixtures/local/master/certs/acmephp.com/public/cert.pem');
+        $this->assertFileExists(__DIR__.'/../Cli/Fixtures/local/master/certs/acmephp.com/private/combined.pem');
+        $this->assertFileExists(__DIR__.'/../Cli/Fixtures/local/master/certs/acmephp.com/public/chain.pem');
+        $this->assertFileExists(__DIR__.'/../Cli/Fixtures/local/master/certs/acmephp.com/public/fullchain.pem');
 
         /*
          * Mock monitoring handlers

--- a/tests/Cli/Repository/AbstractRepositoryTest.php
+++ b/tests/Cli/Repository/AbstractRepositoryTest.php
@@ -67,8 +67,8 @@ abstract class AbstractRepositoryTest extends \PHPUnit_Framework_TestCase
     {
         $this->repository->storeAccountKeyPair(new KeyPair(new PublicKey('public'), new PrivateKey('private')));
 
-        $this->assertEquals("public\n", $this->master->read('private/_account/public.pem'));
-        $this->assertEquals("private\n", $this->master->read('private/_account/private.pem'));
+        $this->assertEquals("public\n", $this->master->read('account/key.public.pem'));
+        $this->assertEquals("private\n", $this->master->read('account/key.private.pem'));
     }
 
     public function testLoadAccountKeyPair()
@@ -93,8 +93,8 @@ abstract class AbstractRepositoryTest extends \PHPUnit_Framework_TestCase
     {
         $this->repository->storeDomainKeyPair('example.com', new KeyPair(new PublicKey('public'), new PrivateKey('private')));
 
-        $this->assertEquals("public\n", $this->master->read('private/example.com/public.pem'));
-        $this->assertEquals("private\n", $this->master->read('private/example.com/private.pem'));
+        $this->assertEquals("public\n", $this->master->read('certs/example.com/private/key.public.pem'));
+        $this->assertEquals("private\n", $this->master->read('certs/example.com/private/key.private.pem'));
     }
 
     public function testLoadDomainKeyPair()
@@ -128,7 +128,7 @@ abstract class AbstractRepositoryTest extends \PHPUnit_Framework_TestCase
 
         $this->repository->storeDomainAuthorizationChallenge('example.com', $challenge);
 
-        $json = $this->master->read('private/example.com/authorization_challenge.json');
+        $json = $this->master->read('var/example.com/authorization_challenge.json');
         $this->assertJson($json);
 
         $data = json_decode($json, true);
@@ -180,7 +180,7 @@ abstract class AbstractRepositoryTest extends \PHPUnit_Framework_TestCase
 
         $this->repository->storeDomainDistinguishedName('example.com', $dn);
 
-        $json = $this->master->read('private/example.com/distinguished_name.json');
+        $json = $this->master->read('var/example.com/distinguished_name.json');
         $this->assertJson($json);
 
         $data = json_decode($json, true);
@@ -229,10 +229,10 @@ abstract class AbstractRepositoryTest extends \PHPUnit_Framework_TestCase
         $this->repository->storeDomainKeyPair('example.com', new KeyPair(new PublicKey('public'), new PrivateKey('private')));
         $this->repository->storeDomainCertificate('example.com', $cert);
 
-        $this->assertEquals(self::$certPem."\n", $this->master->read('certs/example.com/cert.pem'));
-        $this->assertEquals(self::$issuerCertPem."\n", $this->master->read('certs/example.com/chain.pem'));
-        $this->assertEquals(self::$certPem."\n".self::$issuerCertPem."\n", $this->master->read('certs/example.com/fullchain.pem'));
-        $this->assertEquals(self::$certPem."\n".self::$issuerCertPem."\nprivate\n", $this->master->read('private/example.com/combined.pem'));
+        $this->assertEquals(self::$certPem."\n".self::$issuerCertPem."\nprivate\n", $this->master->read('certs/example.com/private/combined.pem'));
+        $this->assertEquals(self::$certPem."\n", $this->master->read('certs/example.com/public/cert.pem'));
+        $this->assertEquals(self::$issuerCertPem."\n", $this->master->read('certs/example.com/public/chain.pem'));
+        $this->assertEquals(self::$certPem."\n".self::$issuerCertPem."\n", $this->master->read('certs/example.com/public/fullchain.pem'));
     }
 
     public function testLoadDomainCertificate()

--- a/tests/Cli/Repository/RepositoryWithBackupTest.php
+++ b/tests/Cli/Repository/RepositoryWithBackupTest.php
@@ -24,32 +24,32 @@ class RepositoryWithBackupTest extends AbstractRepositoryTest
     {
         parent::testStoreAccountKeyPair();
 
-        $this->assertEquals("public\n", $this->backup->read('private/_account/public.pem'));
-        $this->assertEquals("private\n", $this->backup->read('private/_account/private.pem'));
+        $this->assertEquals("public\n", $this->backup->read('account/key.public.pem'));
+        $this->assertEquals("private\n", $this->backup->read('account/key.private.pem'));
     }
 
     public function testStoreDomainKeyPair()
     {
         parent::testStoreDomainKeyPair();
 
-        $this->assertEquals("public\n", $this->backup->read('private/example.com/public.pem'));
-        $this->assertEquals("private\n", $this->backup->read('private/example.com/private.pem'));
+        $this->assertEquals("public\n", $this->backup->read('certs/example.com/private/key.public.pem'));
+        $this->assertEquals("private\n", $this->backup->read('certs/example.com/private/key.private.pem'));
     }
 
     public function testStoreDomainDistinguishedName()
     {
         parent::testStoreDomainDistinguishedName();
 
-        $this->assertJson($this->backup->read('private/example.com/distinguished_name.json'));
+        $this->assertJson($this->backup->read('var/example.com/distinguished_name.json'));
     }
 
     public function testStoreDomainCertificate()
     {
         parent::testStoreDomainCertificate();
 
-        $this->assertEquals(self::$certPem."\n", $this->backup->read('certs/example.com/cert.pem'));
-        $this->assertEquals(self::$issuerCertPem."\n", $this->backup->read('certs/example.com/chain.pem'));
-        $this->assertEquals(self::$certPem."\n".self::$issuerCertPem."\n", $this->backup->read('certs/example.com/fullchain.pem'));
-        $this->assertEquals(self::$certPem."\n".self::$issuerCertPem."\nprivate\n", $this->backup->read('private/example.com/combined.pem'));
+        $this->assertEquals(self::$certPem."\n".self::$issuerCertPem."\nprivate\n", $this->backup->read('certs/example.com/private/combined.pem'));
+        $this->assertEquals(self::$certPem."\n", $this->backup->read('certs/example.com/public/cert.pem'));
+        $this->assertEquals(self::$issuerCertPem."\n", $this->backup->read('certs/example.com/public/chain.pem'));
+        $this->assertEquals(self::$certPem."\n".self::$issuerCertPem."\n", $this->backup->read('certs/example.com/public/fullchain.pem'));
     }
 }

--- a/tests/Cli/Repository/RepositoryWithoutBackupTest.php
+++ b/tests/Cli/Repository/RepositoryWithoutBackupTest.php
@@ -24,32 +24,32 @@ class RepositoryWithoutBackupTest extends AbstractRepositoryTest
     {
         parent::testStoreAccountKeyPair();
 
-        $this->assertFalse($this->backup->has('private/_account/public.pem'));
-        $this->assertFalse($this->backup->has('private/_account/private.pem'));
+        $this->assertFalse($this->backup->has('account/key.public.pem'));
+        $this->assertFalse($this->backup->has('account/key.private.pem'));
     }
 
     public function testStoreDomainKeyPair()
     {
         parent::testStoreDomainKeyPair();
 
-        $this->assertFalse($this->backup->has('private/example.com/public.pem'));
-        $this->assertFalse($this->backup->has('private/example.com/private.pem'));
+        $this->assertFalse($this->backup->has('certs/acmephp.com/private/key.public.pem'));
+        $this->assertFalse($this->backup->has('certs/acmephp.com/private/key.private.pem'));
     }
 
     public function testStoreDomainDistinguishedName()
     {
         parent::testStoreDomainDistinguishedName();
 
-        $this->assertFalse($this->backup->has('private/example.com/distinguished_name.json'));
+        $this->assertFalse($this->backup->has('var/example.com/distinguished_name.json'));
     }
 
     public function testStoreDomainCertificate()
     {
         parent::testStoreDomainCertificate();
 
-        $this->assertFalse($this->backup->has('certs/example.com/cert.pem'));
-        $this->assertFalse($this->backup->has('certs/example.com/chain.pem'));
-        $this->assertFalse($this->backup->has('certs/example.com/fullchain.pem'));
-        $this->assertFalse($this->backup->has('private/example.com/combined.pem'));
+        $this->assertFalse($this->backup->has('certs/example.com/private/combined.pem'));
+        $this->assertFalse($this->backup->has('certs/example.com/public/cert.pem'));
+        $this->assertFalse($this->backup->has('certs/example.com/public/chain.pem'));
+        $this->assertFalse($this->backup->has('certs/example.com/public/fullchain.pem'));
     }
 }

--- a/tests/Cli/SftpNginxProxyApplicationTest.php
+++ b/tests/Cli/SftpNginxProxyApplicationTest.php
@@ -62,26 +62,26 @@ class SftpNginxProxyApplicationTest extends AbstractApplicationTest
         $this->assertFileExists(__DIR__.'/../Cli/Fixtures/local/master/nginxproxy/acmephp.com.key');
 
         // Backup
-        $this->assertFileExists(__DIR__.'/../Cli/Fixtures/local/backup/private/acmephp.com/private.pem');
-        $this->assertFileExists(__DIR__.'/../Cli/Fixtures/local/backup/private/acmephp.com/public.pem');
-        $this->assertFileExists(__DIR__.'/../Cli/Fixtures/local/backup/certs/acmephp.com/cert.pem');
-        $this->assertFileExists(__DIR__.'/../Cli/Fixtures/local/backup/private/acmephp.com/combined.pem');
-        $this->assertFileExists(__DIR__.'/../Cli/Fixtures/local/backup/certs/acmephp.com/chain.pem');
-        $this->assertFileExists(__DIR__.'/../Cli/Fixtures/local/backup/certs/acmephp.com/fullchain.pem');
+        $this->assertFileExists(__DIR__.'/../Cli/Fixtures/local/backup/certs/acmephp.com/private/key.private.pem');
+        $this->assertFileExists(__DIR__.'/../Cli/Fixtures/local/backup/certs/acmephp.com/private/key.public.pem');
+        $this->assertFileExists(__DIR__.'/../Cli/Fixtures/local/backup/certs/acmephp.com/private/combined.pem');
+        $this->assertFileExists(__DIR__.'/../Cli/Fixtures/local/backup/certs/acmephp.com/public/cert.pem');
+        $this->assertFileExists(__DIR__.'/../Cli/Fixtures/local/backup/certs/acmephp.com/public/chain.pem');
+        $this->assertFileExists(__DIR__.'/../Cli/Fixtures/local/backup/certs/acmephp.com/public/fullchain.pem');
 
         // Backup nginxproxy
         $this->assertFileExists(__DIR__.'/../Cli/Fixtures/local/backup/nginxproxy/acmephp.com.crt');
         $this->assertFileExists(__DIR__.'/../Cli/Fixtures/local/backup/nginxproxy/acmephp.com.key');
 
         // SFTP
-        $this->assertTrue($sftpFilesystem->has('private/_account/private.pem'));
-        $this->assertTrue($sftpFilesystem->has('private/_account/public.pem'));
-        $this->assertTrue($sftpFilesystem->has('private/acmephp.com/private.pem'));
-        $this->assertTrue($sftpFilesystem->has('private/acmephp.com/public.pem'));
-        $this->assertTrue($sftpFilesystem->has('certs/acmephp.com/fullchain.pem'));
-        $this->assertTrue($sftpFilesystem->has('certs/acmephp.com/cert.pem'));
-        $this->assertTrue($sftpFilesystem->has('certs/acmephp.com/chain.pem'));
-        $this->assertTrue($sftpFilesystem->has('private/acmephp.com/combined.pem'));
+        $this->assertTrue($sftpFilesystem->has('account/key.private.pem'));
+        $this->assertTrue($sftpFilesystem->has('account/key.public.pem'));
+        $this->assertTrue($sftpFilesystem->has('certs/acmephp.com/private/key.private.pem'));
+        $this->assertTrue($sftpFilesystem->has('certs/acmephp.com/private/key.public.pem'));
+        $this->assertTrue($sftpFilesystem->has('certs/acmephp.com/private/combined.pem'));
+        $this->assertTrue($sftpFilesystem->has('certs/acmephp.com/public/cert.pem'));
+        $this->assertTrue($sftpFilesystem->has('certs/acmephp.com/public/chain.pem'));
+        $this->assertTrue($sftpFilesystem->has('certs/acmephp.com/public/fullchain.pem'));
         $this->assertTrue($sftpFilesystem->has('nginxproxy/acmephp.com.crt'));
         $this->assertTrue($sftpFilesystem->has('nginxproxy/acmephp.com.key'));
     }


### PR DESCRIPTION
I'm not happy with #96, because combine.pem file, is now with files unrelated to certificates.

Here is a new directory tree. This separate certificate file from working/cache stuff, and allow users to zip all files at once, or only public

```
├── account
│   ├── key.private.pem
│   └── key.public.pem
├── var
│   └── acmephp.com
│       ├── 35e10972385c8e8e7ef4e5b68813f0b0115045a9
│       │   └── certificate_order.json
│       ├── authorization_challenge.json
│       └── distinguished_name.json
└── certs
    └── acmephp.com
        ├── private
        │   ├── combined.pem
        │   ├── key.private.pem
        │   └── key.public.pem
        └── public
            ├── cert.pem
            ├── chain.pem
            └── fullchain.pem
```