### PR TITLE
Bump Swiftmailer version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "symfony/serializer": "^3.0",
         "symfony/yaml": "^3.0",
         "monolog/monolog": "^1.19",
-        "swiftmailer/swiftmailer": "^5.4",
+        "swiftmailer/swiftmailer": "^6.0",
         "league/flysystem": "^1.0.19",
         "league/flysystem-sftp": "^1.0.7",
         "webmozart/assert": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "symfony/serializer": "^3.0",
         "symfony/yaml": "^3.0",
         "monolog/monolog": "^1.19",
-        "swiftmailer/swiftmailer": "^6.0",
+        "swiftmailer/swiftmailer": "^5.4|^6.0",
         "league/flysystem": "^1.0.19",
         "league/flysystem-sftp": "^1.0.7",
         "webmozart/assert": "^1.0",


### PR DESCRIPTION
 Bump Swiftmailer version to prevent composer conflicts when installing into a Laravel 5.5 project