### PR TITLE
Use more appropriate Accept and Content-Type headers

### DIFF
--- a/src/Core/Http/SecureHttpClient.php
+++ b/src/Core/Http/SecureHttpClient.php
@@ -326,10 +326,10 @@ class SecureHttpClient
     private function createRequest($method, $endpoint, $data)
     {
         $request = new Request($method, $endpoint);
-        $request = $request->withHeader('Accept', 'application/json');
+        $request = $request->withHeader('Accept', 'application/json,application/jose+json,');
 
         if ('POST' === $method && is_array($data)) {
-            $request = $request->withHeader('Content-Type', 'application/json');
+            $request = $request->withHeader('Content-Type', 'application/jose+json');
             $request = $request->withBody(\GuzzleHttp\Psr7\stream_for(json_encode($data)));
         }
 


### PR DESCRIPTION
This morning I have been getting `415 Unsupported Media Type` errors when trying to talk to Let's Encrypt, with an error of `Content-Type must be "application/jose+json"`.

Adjust the appropriate headers fixes this.