### PR TITLE
Fix array to object convertion

### DIFF
--- a/src/Core/AcmeClient.php
+++ b/src/Core/AcmeClient.php
@@ -141,7 +141,7 @@ class AcmeClient implements AcmeClientV2Interface
                         'value' => $domain,
                     ];
                 },
-                $domains
+                array_values($domains)
             ),
         ];
 


### PR DESCRIPTION
In some case (when a domain is duplicate in the list of SANs), the function array_unique does not re-arrange indexes. Which generate an error from ACME server when they are trying to parse the request and expect a try array.