### PR TITLE
Fix nginxproxy crt generation

### DIFF
--- a/src/Cli/Action/BuildNginxProxyAction.php
+++ b/src/Cli/Action/BuildNginxProxyAction.php
@@ -54,7 +54,7 @@ class BuildNginxProxyAction implements ActionInterface
         }, $certificate->getIssuerChain());
 
         // Full chain
-        $fullChainPem = $certificate->getPEM().implode("\n", $issuerChain);
+        $fullChainPem = $certificate->getPEM().PHP_EOL.implode("\n", $issuerChain);
 
         $this->repository->save('nginxproxy/'.$domain.'.crt', $fullChainPem);
     }

--- a/src/Cli/Action/BuildNginxProxyAction.php
+++ b/src/Cli/Action/BuildNginxProxyAction.php
@@ -54,7 +54,7 @@ class BuildNginxProxyAction implements ActionInterface
         }, $certificate->getIssuerChain());
 
         // Full chain
-        $fullChainPem = $certificate->getPEM().PHP_EOL.implode("\n", $issuerChain);
+        $fullChainPem = $certificate->getPEM()."\n".implode("\n", $issuerChain);
 
         $this->repository->save('nginxproxy/'.$domain.'.crt', $fullChainPem);
     }


### PR DESCRIPTION
Fix crt file generation in nginxproxy.

The issue here was that `implode("\n", $issuerChain)` part worked perfectly but there's no newline between certificate and chain. Due to this invalid `crt` was getting generated.

Fixed it by adding a newline.