### PR TITLE
Fix nginxproxy wildcard certificates

### DIFF
--- a/src/Cli/Action/BuildNginxProxyAction.php
+++ b/src/Cli/Action/BuildNginxProxyAction.php
@@ -46,6 +46,9 @@ class BuildNginxProxyAction implements ActionInterface
         $privateKey = $response->getCertificateRequest()->getKeyPair()->getPrivateKey();
         $certificate = $response->getCertificate();
 
+        // To handle wildcard certs
+        $domain = ltrim($domain, '*.');
+
         $this->repository->save('nginxproxy/'.$domain.'.key', $privateKey->getPEM());
 
         // Issuer chain


### PR DESCRIPTION
Fix naming of crt and key file in nginxproxy to handle wildcard certificates. See - https://github.com/jwilder/nginx-proxy#wildcard-certificates

> Wildcard certificates and keys should be named after the domain name with a .crt and .key extension. For example VIRTUAL_HOST=foo.bar.com would use cert name bar.com.crt and bar.com.key.

In existing code, the common name would be `*.bar.com`. Hence to fix it, we remove `*.` from front.