### PR TITLE
Add support for ECDSA

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ config file like
 
 ```yaml
 contact_email: contact@company
+key_type: RSA                                          # RSA or EC (for ECDSA). Default "RSA"
 
 defaults:
   distinguished_name:

--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,8 @@
         "certificate",
         "ssl",
         "openssl",
+        "RSA",
+        "ECDSA",
         "CSR",
         "x509",
         "cli"
@@ -33,6 +35,7 @@
         "ext-hash": "*",
         "ext-json": "*",
         "ext-filter": "*",
+        "ext-mbstring": "*",
         "ext-openssl": "*",
         "aws/aws-sdk-php": "^3.38",
         "guzzlehttp/guzzle": "^6.0",

--- a/composer.json
+++ b/composer.json
@@ -37,6 +37,7 @@
         "ext-filter": "*",
         "ext-mbstring": "*",
         "ext-openssl": "*",
+        "lib-openssl": ">=0.9.8",
         "aws/aws-sdk-php": "^3.38",
         "guzzlehttp/guzzle": "^6.0",
         "guzzlehttp/psr7": "^1.0",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -15,6 +15,10 @@
         </testsuite>
     </testsuites>
 
+    <listeners>
+        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener" />
+    </listeners>
+
     <filter>
         <whitelist>
             <directory>src/</directory>

--- a/src/Cli/Command/Helper/KeyOptionCommandTrait.php
+++ b/src/Cli/Command/Helper/KeyOptionCommandTrait.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Acme PHP project.
+ *
+ * (c) Titouan Galopin <galopintitouan@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace AcmePhp\Cli\Command\Helper;
+
+use AcmePhp\Ssl\Generator\EcKey\EcKeyOption;
+use AcmePhp\Ssl\Generator\RsaKey\RsaKeyOption;
+
+/**
+ * @author Jérémy Derussé <jeremy@derusse.com>
+ */
+trait KeyOptionCommandTrait
+{
+    private function createKeyOption($keyType)
+    {
+        switch (\strtoupper($keyType)) {
+            case 'RSA':
+                return new RsaKeyOption();
+            case 'EC':
+                return new EcKeyOption();
+            default:
+                throw new \InvalidArgumentException(sprintf('The keyType "%s" is not valid. Supported types are: RSA, EC', \strtoupper($keyType)));
+        }
+    }
+}

--- a/src/Cli/Configuration/DomainConfiguration.php
+++ b/src/Cli/Configuration/DomainConfiguration.php
@@ -48,7 +48,23 @@ class DomainConfiguration implements ConfigurationInterface
                         ->ifTrue(function ($item) {
                             return !filter_var($item, FILTER_VALIDATE_EMAIL);
                         })
-                        ->thenInvalid('The email "%s" is not valid.')
+                        ->thenInvalid('The email %s is not valid.')
+                    ->end()
+                ->end()
+                ->scalarNode('key_type')
+                    ->info('Type of private key (RSA or EC).')
+                    ->defaultValue('RSA')
+                    ->beforeNormalization()
+                        ->ifString()
+                        ->then(function ($conf) {
+                            return \strtoupper($conf);
+                        })
+                    ->end()
+                    ->validate()
+                        ->ifTrue(function ($item) {
+                            return !\in_array($item, ['RSA', 'EC']);
+                        })
+                        ->thenInvalid('The keyType %s is not valid. Supported types are: RSA, EC')
                     ->end()
                 ->end()
             ->end()
@@ -95,7 +111,7 @@ class DomainConfiguration implements ConfigurationInterface
                 ->ifTrue(function ($item) {
                     return !isset($item['name']);
                 })
-                ->thenInvalid('The name attribute "%s" is required in install property.')
+                ->thenInvalid('The name attribute %s is required in install property.')
             ->end();
     }
 
@@ -116,7 +132,7 @@ class DomainConfiguration implements ConfigurationInterface
                         ->ifTrue(function ($item) {
                             return 2 !== \strlen($item);
                         })
-                        ->thenInvalid('The country code "%s" is not valid.')
+                        ->thenInvalid('The country code %s is not valid.')
                     ->end()
                 ->end()
                 ->scalarNode('state')
@@ -142,7 +158,7 @@ class DomainConfiguration implements ConfigurationInterface
                         ->ifTrue(function ($item) {
                             return !filter_var($item, FILTER_VALIDATE_EMAIL);
                         })
-                        ->thenInvalid('The email "%s" is not valid.')
+                        ->thenInvalid('The email %s is not valid.')
                     ->end()
                 ->end()
             ->end();
@@ -178,7 +194,7 @@ class DomainConfiguration implements ConfigurationInterface
                                 ->ifTrue(function ($item) {
                                     return !isset($item['action']);
                                 })
-                                ->thenInvalid('The action attribute "%s" is required in install property.')
+                                ->thenInvalid('The action attribute %s is required in install property.')
                             ->end()
                         ->end()
                     ->end()

--- a/src/Cli/Resources/services.xml
+++ b/src/Cli/Resources/services.xml
@@ -22,10 +22,19 @@
         </service>
 
         <!-- SSL -->
-        <service id="ssl.key_pair_generator" class="AcmePhp\Ssl\Generator\KeyPairGenerator" />
+        <service id="ssl.private_key_generator" class="AcmePhp\Ssl\Generator\ChainPrivateKeyGenerator" public="false" >
+            <argument type="collection">
+                <argument type="service" id="ssl.rsa_key_generator"/>
+                <argument type="service" id="ssl.ec_key_generator"/>
+            </argument>
+        </service>
+        <service id="ssl.rsa_key_generator" class="AcmePhp\Ssl\Generator\RsaKey\RsaKeyGenerator" public="false" />
+        <service id="ssl.ec_key_generator" class="AcmePhp\Ssl\Generator\EcKey\EcKeyGenerator" public="false" />
+        <service id="ssl.key_pair_generator" class="AcmePhp\Ssl\Generator\KeyPairGenerator">
+            <argument type="service" id="ssl.private_key_generator"/>
+        </service>
         <service id="ssl.certificate_parser" class="AcmePhp\Ssl\Parser\CertificateParser" />
         <service id="ssl.key_parser" class="AcmePhp\Ssl\Parser\KeyParser" />
-        <service id="ssl.certificate_parser" class="AcmePhp\Ssl\Parser\CertificateParser" />
         <service id="ssl.csr_signer" class="AcmePhp\Ssl\Signer\CertificateRequestSigner" />
         <service id="ssl.data_signer" class="AcmePhp\Ssl\Signer\DataSigner" />
 

--- a/src/Ssl/Exception/KeyGenerationException.php
+++ b/src/Ssl/Exception/KeyGenerationException.php
@@ -14,6 +14,6 @@ namespace AcmePhp\Ssl\Exception;
 /**
  * @author Jérémy Derussé <jeremy@derusse.com>
  */
-class KeyPairGenerationException extends KeyGenerationException
+class KeyGenerationException extends AcmeSslException
 {
 }

--- a/src/Ssl/Generator/ChainPrivateKeyGenerator.php
+++ b/src/Ssl/Generator/ChainPrivateKeyGenerator.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the Acme PHP project.
+ *
+ * (c) Titouan Galopin <galopintitouan@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace AcmePhp\Ssl\Generator;
+
+/**
+ * Generate random RSA private key using OpenSSL.
+ *
+ * @author Jérémy Derussé <jeremy@derusse.com>
+ */
+class ChainPrivateKeyGenerator implements PrivateKeyGeneratorInterface
+{
+    /** @var PrivateKeyGeneratorInterface[] */
+    private $generators;
+
+    /**
+     * @param PrivateKeyGeneratorInterface[] $generators
+     */
+    public function __construct($generators)
+    {
+        $this->generators = $generators;
+    }
+
+    public function generatePrivateKey(KeyOption $keyOption)
+    {
+        foreach ($this->generators as $generator) {
+            if ($generator->supportsKeyOption($keyOption)) {
+                return $generator->generatePrivateKey($keyOption);
+            }
+        }
+
+        throw new \LogicException(
+            sprintf('Unable to find a generator for a key option of type %s', \get_class($keyOption))
+        );
+    }
+
+    public function supportsKeyOption(KeyOption $keyOption)
+    {
+        foreach ($this->generators as $generator) {
+            if ($generator->supportsKeyOption($keyOption)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Ssl/Generator/DhKey/DhKeyGenerator.php
+++ b/src/Ssl/Generator/DhKey/DhKeyGenerator.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace AcmePhp\Ssl\Generator\RsaKey;
+namespace AcmePhp\Ssl\Generator\DhKey;
 
 use AcmePhp\Ssl\Generator\KeyOption;
 use AcmePhp\Ssl\Generator\OpensslPrivateKeyGeneratorTrait;
@@ -17,31 +17,34 @@ use AcmePhp\Ssl\Generator\PrivateKeyGeneratorInterface;
 use Webmozart\Assert\Assert;
 
 /**
- * Generate random RSA private key using OpenSSL.
+ * Generate random DH private key using OpenSSL.
  *
  * @author Jérémy Derussé <jeremy@derusse.com>
  */
-class RsaKeyGenerator implements PrivateKeyGeneratorInterface
+class DhKeyGenerator implements PrivateKeyGeneratorInterface
 {
     use OpensslPrivateKeyGeneratorTrait;
 
     /**
-     * @param RsaKeyOption|KeyOption $keyOption
+     * @param DhKeyOption|KeyOption $keyOption
      */
     public function generatePrivateKey(KeyOption $keyOption)
     {
-        Assert::isInstanceOf($keyOption, RsaKeyOption::class);
+        Assert::isInstanceOf($keyOption, DhKeyOption::class);
 
         return $this->generatePrivateKeyFromOpensslOptions(
             [
-                'private_key_type' => OPENSSL_KEYTYPE_RSA,
-                'private_key_bits' => $keyOption->getBits(),
+                'private_key_type' => OPENSSL_KEYTYPE_DH,
+                'dh' => [
+                    'p' => $keyOption->getPrime(),
+                    'g' => $keyOption->getGenerator(),
+                ],
             ]
         );
     }
 
     public function supportsKeyOption(KeyOption $keyOption)
     {
-        return $keyOption instanceof RsaKeyOption;
+        return $keyOption instanceof DhKeyOption;
     }
 }

--- a/src/Ssl/Generator/DhKey/DhKeyOption.php
+++ b/src/Ssl/Generator/DhKey/DhKeyOption.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the Acme PHP project.
+ *
+ * (c) Titouan Galopin <galopintitouan@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace AcmePhp\Ssl\Generator\DhKey;
+
+use AcmePhp\Ssl\Generator\KeyOption;
+
+class DhKeyOption implements KeyOption
+{
+    /** @var string */
+    private $generator;
+    /** @var string */
+    private $prime;
+
+    /**
+     * @param string $prime     Hexadecimal representation of the prime
+     * @param string $generator Hexadecimal representation of the generator: ie. 02
+     *
+     * @see https://tools.ietf.org/html/rfc3526 how to choose a prime and generator numbers
+     */
+    public function __construct($prime, $generator = '02')
+    {
+        $this->generator = pack('H*', $generator);
+        $this->prime = pack('H*', $prime);
+    }
+
+    /**
+     * @return string
+     */
+    public function getGenerator()
+    {
+        return $this->generator;
+    }
+
+    /**
+     * @return string
+     */
+    public function getPrime()
+    {
+        return $this->prime;
+    }
+}

--- a/src/Ssl/Generator/DsaKey/DsaKeyGenerator.php
+++ b/src/Ssl/Generator/DsaKey/DsaKeyGenerator.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace AcmePhp\Ssl\Generator\RsaKey;
+namespace AcmePhp\Ssl\Generator\DsaKey;
 
 use AcmePhp\Ssl\Generator\KeyOption;
 use AcmePhp\Ssl\Generator\OpensslPrivateKeyGeneratorTrait;
@@ -17,24 +17,24 @@ use AcmePhp\Ssl\Generator\PrivateKeyGeneratorInterface;
 use Webmozart\Assert\Assert;
 
 /**
- * Generate random RSA private key using OpenSSL.
+ * Generate random DSA private key using OpenSSL.
  *
  * @author Jérémy Derussé <jeremy@derusse.com>
  */
-class RsaKeyGenerator implements PrivateKeyGeneratorInterface
+class DsaKeyGenerator implements PrivateKeyGeneratorInterface
 {
     use OpensslPrivateKeyGeneratorTrait;
 
     /**
-     * @param RsaKeyOption|KeyOption $keyOption
+     * @param DsaKeyOption|KeyOption $keyOption
      */
     public function generatePrivateKey(KeyOption $keyOption)
     {
-        Assert::isInstanceOf($keyOption, RsaKeyOption::class);
+        Assert::isInstanceOf($keyOption, DsaKeyOption::class);
 
         return $this->generatePrivateKeyFromOpensslOptions(
             [
-                'private_key_type' => OPENSSL_KEYTYPE_RSA,
+                'private_key_type' => OPENSSL_KEYTYPE_DSA,
                 'private_key_bits' => $keyOption->getBits(),
             ]
         );
@@ -42,6 +42,6 @@ class RsaKeyGenerator implements PrivateKeyGeneratorInterface
 
     public function supportsKeyOption(KeyOption $keyOption)
     {
-        return $keyOption instanceof RsaKeyOption;
+        return $keyOption instanceof DsaKeyOption;
     }
 }

--- a/src/Ssl/Generator/DsaKey/DsaKeyOption.php
+++ b/src/Ssl/Generator/DsaKey/DsaKeyOption.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Acme PHP project.
+ *
+ * (c) Titouan Galopin <galopintitouan@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace AcmePhp\Ssl\Generator\DsaKey;
+
+use AcmePhp\Ssl\Generator\KeyOption;
+use Webmozart\Assert\Assert;
+
+class DsaKeyOption implements KeyOption
+{
+    /** @var int */
+    private $bits;
+
+    public function __construct($bits = 2048)
+    {
+        Assert::integer($bits);
+
+        $this->bits = $bits;
+    }
+
+    /**
+     * @return int
+     */
+    public function getBits()
+    {
+        return $this->bits;
+    }
+}

--- a/src/Ssl/Generator/EcKey/EcKeyGenerator.php
+++ b/src/Ssl/Generator/EcKey/EcKeyGenerator.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of the Acme PHP project.
+ *
+ * (c) Titouan Galopin <galopintitouan@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace AcmePhp\Ssl\Generator\EcKey;
+
+use AcmePhp\Ssl\Exception\KeyGenerationException;
+use AcmePhp\Ssl\Exception\KeyPairGenerationException;
+use AcmePhp\Ssl\Generator\KeyOption;
+use AcmePhp\Ssl\Generator\PrivateKeyGeneratorInterface;
+use AcmePhp\Ssl\PrivateKey;
+use Webmozart\Assert\Assert;
+
+/**
+ * Generate random EC private key using OpenSSL.
+ *
+ * @author Jérémy Derussé <jeremy@derusse.com>
+ */
+class EcKeyGenerator implements PrivateKeyGeneratorInterface
+{
+    /**
+     * @param EcKeyOption|KeyOption $keyOption
+     */
+    public function generatePrivateKey(KeyOption $keyOption)
+    {
+        Assert::isInstanceOf($keyOption, EcKeyOption::class);
+
+        $resource = openssl_pkey_new(
+            [
+                'private_key_type' => OPENSSL_KEYTYPE_EC,
+                'curve_name' => $keyOption->getCurveName(),
+            ]
+        );
+
+        if (!$resource) {
+            throw new KeyGenerationException(
+                sprintf('OpenSSL key creation failed during generation with error: %s', openssl_error_string())
+            );
+        }
+        if (!openssl_pkey_export($resource, $privateKey)) {
+            throw new KeyPairGenerationException(
+                sprintf('OpenSSL key export failed during generation with error: %s', openssl_error_string())
+            );
+        }
+
+        return new PrivateKey($privateKey);
+    }
+
+    public function supportsKeyOption(KeyOption $keyOption)
+    {
+        return $keyOption instanceof EcKeyOption;
+    }
+}

--- a/src/Ssl/Generator/EcKey/EcKeyGenerator.php
+++ b/src/Ssl/Generator/EcKey/EcKeyGenerator.php
@@ -11,11 +11,9 @@
 
 namespace AcmePhp\Ssl\Generator\EcKey;
 
-use AcmePhp\Ssl\Exception\KeyGenerationException;
-use AcmePhp\Ssl\Exception\KeyPairGenerationException;
 use AcmePhp\Ssl\Generator\KeyOption;
+use AcmePhp\Ssl\Generator\OpensslPrivateKeyGeneratorTrait;
 use AcmePhp\Ssl\Generator\PrivateKeyGeneratorInterface;
-use AcmePhp\Ssl\PrivateKey;
 use Webmozart\Assert\Assert;
 
 /**
@@ -25,6 +23,8 @@ use Webmozart\Assert\Assert;
  */
 class EcKeyGenerator implements PrivateKeyGeneratorInterface
 {
+    use OpensslPrivateKeyGeneratorTrait;
+
     /**
      * @param EcKeyOption|KeyOption $keyOption
      */
@@ -32,25 +32,12 @@ class EcKeyGenerator implements PrivateKeyGeneratorInterface
     {
         Assert::isInstanceOf($keyOption, EcKeyOption::class);
 
-        $resource = openssl_pkey_new(
+        return $this->generatePrivateKeyFromOpensslOptions(
             [
                 'private_key_type' => OPENSSL_KEYTYPE_EC,
                 'curve_name' => $keyOption->getCurveName(),
             ]
         );
-
-        if (!$resource) {
-            throw new KeyGenerationException(
-                sprintf('OpenSSL key creation failed during generation with error: %s', openssl_error_string())
-            );
-        }
-        if (!openssl_pkey_export($resource, $privateKey)) {
-            throw new KeyPairGenerationException(
-                sprintf('OpenSSL key export failed during generation with error: %s', openssl_error_string())
-            );
-        }
-
-        return new PrivateKey($privateKey);
     }
 
     public function supportsKeyOption(KeyOption $keyOption)

--- a/src/Ssl/Generator/EcKey/EcKeyGenerator.php
+++ b/src/Ssl/Generator/EcKey/EcKeyGenerator.php
@@ -30,6 +30,10 @@ class EcKeyGenerator implements PrivateKeyGeneratorInterface
      */
     public function generatePrivateKey(KeyOption $keyOption)
     {
+        if (\PHP_VERSION_ID < 70100) {
+            throw new \LogicException('The generation of ECDSA requires a version of PHP >= 7.1');
+        }
+
         Assert::isInstanceOf($keyOption, EcKeyOption::class);
 
         return $this->generatePrivateKeyFromOpensslOptions(

--- a/src/Ssl/Generator/EcKey/EcKeyOption.php
+++ b/src/Ssl/Generator/EcKey/EcKeyOption.php
@@ -21,6 +21,10 @@ class EcKeyOption implements KeyOption
 
     public function __construct($curveName = 'secp384r1')
     {
+        if (\PHP_VERSION_ID < 70100) {
+            throw new \LogicException('The generation of ECDSA requires a version of PHP >= 7.1');
+        }
+
         Assert::stringNotEmpty($curveName);
         Assert::oneOf($curveName, openssl_get_curve_names(), 'The given curve %s is not supported. Available curves are: %s');
 

--- a/src/Ssl/Generator/EcKey/EcKeyOption.php
+++ b/src/Ssl/Generator/EcKey/EcKeyOption.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Acme PHP project.
+ *
+ * (c) Titouan Galopin <galopintitouan@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace AcmePhp\Ssl\Generator\EcKey;
+
+use AcmePhp\Ssl\Generator\KeyOption;
+use Webmozart\Assert\Assert;
+
+class EcKeyOption implements KeyOption
+{
+    /** @var string */
+    private $curveName;
+
+    public function __construct($curveName = 'secp384r1')
+    {
+        Assert::stringNotEmpty($curveName);
+        Assert::oneOf($curveName, openssl_get_curve_names(), 'The given curve %s is not supported. Available curves are: %s');
+
+        $this->curveName = $curveName;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCurveName()
+    {
+        return $this->curveName;
+    }
+}

--- a/src/Ssl/Generator/KeyOption.php
+++ b/src/Ssl/Generator/KeyOption.php
@@ -9,11 +9,8 @@
  * file that was distributed with this source code.
  */
 
-namespace AcmePhp\Ssl\Exception;
+namespace AcmePhp\Ssl\Generator;
 
-/**
- * @author Jérémy Derussé <jeremy@derusse.com>
- */
-class KeyPairGenerationException extends KeyGenerationException
+interface KeyOption
 {
 }

--- a/src/Ssl/Generator/KeyPairGenerator.php
+++ b/src/Ssl/Generator/KeyPairGenerator.php
@@ -13,6 +13,8 @@ namespace AcmePhp\Ssl\Generator;
 
 use AcmePhp\Ssl\Exception\KeyGenerationException;
 use AcmePhp\Ssl\Exception\KeyPairGenerationException;
+use AcmePhp\Ssl\Generator\DhKey\DhKeyGenerator;
+use AcmePhp\Ssl\Generator\DsaKey\DsaKeyGenerator;
 use AcmePhp\Ssl\Generator\EcKey\EcKeyGenerator;
 use AcmePhp\Ssl\Generator\RsaKey\RsaKeyGenerator;
 use AcmePhp\Ssl\Generator\RsaKey\RsaKeyOption;
@@ -34,6 +36,8 @@ class KeyPairGenerator
             [
                 new RsaKeyGenerator(),
                 new EcKeyGenerator(),
+                new DhKeyGenerator(),
+                new DsaKeyGenerator(),
             ]
         );
     }

--- a/src/Ssl/Generator/OpensslPrivateKeyGeneratorTrait.php
+++ b/src/Ssl/Generator/OpensslPrivateKeyGeneratorTrait.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Acme PHP project.
+ *
+ * (c) Titouan Galopin <galopintitouan@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace AcmePhp\Ssl\Generator;
+
+use AcmePhp\Ssl\Exception\KeyGenerationException;
+use AcmePhp\Ssl\Exception\KeyPairGenerationException;
+use AcmePhp\Ssl\PrivateKey;
+
+trait OpensslPrivateKeyGeneratorTrait
+{
+    private function generatePrivateKeyFromOpensslOptions(array $opensslOptions)
+    {
+        $resource = openssl_pkey_new($opensslOptions);
+
+        if (!$resource) {
+            throw new KeyGenerationException(
+                sprintf('OpenSSL key creation failed during generation with error: %s', openssl_error_string())
+            );
+        }
+        if (!openssl_pkey_export($resource, $privateKey)) {
+            throw new KeyPairGenerationException(
+                sprintf('OpenSSL key export failed during generation with error: %s', openssl_error_string())
+            );
+        }
+
+        return new PrivateKey($privateKey);
+    }
+}

--- a/src/Ssl/Generator/PrivateKeyGeneratorInterface.php
+++ b/src/Ssl/Generator/PrivateKeyGeneratorInterface.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the Acme PHP project.
+ *
+ * (c) Titouan Galopin <galopintitouan@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace AcmePhp\Ssl\Generator;
+
+use AcmePhp\Ssl\Exception\KeyGenerationException;
+use AcmePhp\Ssl\PrivateKey;
+
+/**
+ * Generate random private key.
+ *
+ * @author Jérémy Derussé <jeremy@derusse.com>
+ */
+interface PrivateKeyGeneratorInterface
+{
+    /**
+     * Generate a PrivateKey.
+     *
+     * @param KeyOption $keyOption configuration of the key to generate
+     *
+     * @throws KeyGenerationException when OpenSSL failed to generate keys
+     *
+     * @return PrivateKey
+     */
+    public function generatePrivateKey(KeyOption $keyOption);
+
+    /**
+     * Returns whether the instance is able to generator a private key from the given option.
+     *
+     * @param KeyOption $keyOption configuration of the key to generate
+     *
+     * @return bool
+     */
+    public function supportsKeyOption(KeyOption $keyOption);
+}

--- a/src/Ssl/Generator/RsaKey/RsaKeyGenerator.php
+++ b/src/Ssl/Generator/RsaKey/RsaKeyGenerator.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of the Acme PHP project.
+ *
+ * (c) Titouan Galopin <galopintitouan@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace AcmePhp\Ssl\Generator\RsaKey;
+
+use AcmePhp\Ssl\Exception\KeyGenerationException;
+use AcmePhp\Ssl\Exception\KeyPairGenerationException;
+use AcmePhp\Ssl\Generator\KeyOption;
+use AcmePhp\Ssl\Generator\PrivateKeyGeneratorInterface;
+use AcmePhp\Ssl\PrivateKey;
+use Webmozart\Assert\Assert;
+
+/**
+ * Generate random RSA private key using OpenSSL.
+ *
+ * @author Jérémy Derussé <jeremy@derusse.com>
+ */
+class RsaKeyGenerator implements PrivateKeyGeneratorInterface
+{
+    /**
+     * @param RsaKeyOption|KeyOption $keyOption
+     */
+    public function generatePrivateKey(KeyOption $keyOption)
+    {
+        Assert::isInstanceOf($keyOption, RsaKeyOption::class);
+
+        $resource = openssl_pkey_new(
+            [
+                'private_key_type' => OPENSSL_KEYTYPE_RSA,
+                'private_key_bits' => $keyOption->getBits(),
+            ]
+        );
+
+        if (!$resource) {
+            throw new KeyGenerationException(
+                sprintf('OpenSSL key creation failed during generation with error: %s', openssl_error_string())
+            );
+        }
+        if (!openssl_pkey_export($resource, $privateKey)) {
+            throw new KeyPairGenerationException(
+                sprintf('OpenSSL key export failed during generation with error: %s', openssl_error_string())
+            );
+        }
+
+        return new PrivateKey($privateKey);
+    }
+
+    public function supportsKeyOption(KeyOption $keyOption)
+    {
+        return $keyOption instanceof RsaKeyOption;
+    }
+}

--- a/src/Ssl/Generator/RsaKey/RsaKeyOption.php
+++ b/src/Ssl/Generator/RsaKey/RsaKeyOption.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Acme PHP project.
+ *
+ * (c) Titouan Galopin <galopintitouan@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace AcmePhp\Ssl\Generator\RsaKey;
+
+use AcmePhp\Ssl\Generator\KeyOption;
+use Webmozart\Assert\Assert;
+
+class RsaKeyOption implements KeyOption
+{
+    /** @var int */
+    private $bits;
+
+    public function __construct($bits = 4096)
+    {
+        Assert::integer($bits);
+
+        $this->bits = $bits;
+    }
+
+    /**
+     * @return int
+     */
+    public function getBits()
+    {
+        return $this->bits;
+    }
+}

--- a/src/Ssl/Parser/KeyParser.php
+++ b/src/Ssl/Parser/KeyParser.php
@@ -58,6 +58,8 @@ class KeyParser
             $details = $rawData['dsa'];
         } elseif (OPENSSL_KEYTYPE_DH === $rawData['type']) {
             $details = $rawData['dh'];
+        } elseif (OPENSSL_KEYTYPE_EC === $rawData['type']) {
+            $details = $rawData['ec'];
         }
 
         return new ParsedKey($key, $rawData['key'], $rawData['bits'], $rawData['type'], $details);

--- a/src/Ssl/PrivateKey.php
+++ b/src/Ssl/PrivateKey.php
@@ -38,7 +38,11 @@ class PrivateKey extends Key
      */
     public function getPublicKey()
     {
-        return new PublicKey(openssl_pkey_get_details($this->getResource())['key']);
+        if (!$details = openssl_pkey_get_details($this->getResource())) {
+            throw new KeyFormatException(sprintf('Failed to extract public key: %s', openssl_error_string()));
+        }
+
+        return new PublicKey($details['key']);
     }
 
     /**

--- a/src/Ssl/Signer/DataSigner.php
+++ b/src/Ssl/Signer/DataSigner.php
@@ -64,36 +64,6 @@ class DataSigner
     }
 
     /**
-     * Convert a ECDSA signature into DER.
-     *
-     * The code is a copy/paste from another lib (web-token/jwt-core) which is not compatible with php <= 7.0
-     *
-     * @see https://github.com/web-token/jwt-core/blob/master/Util/ECSignature.php
-     */
-    private function ECDSAtoDER($signature, $partLength)
-    {
-        $signature = \unpack('H*', $signature)[1];
-        if (\mb_strlen($signature, '8bit') !== 2 * $partLength) {
-            throw new DataSigningException('Invalid length.');
-        }
-        $R = \mb_substr($signature, 0, $partLength, '8bit');
-        $S = \mb_substr($signature, $partLength, null, '8bit');
-
-        $R = $this->preparePositiveInteger($R);
-        $Rl = \mb_strlen($R, '8bit') / 2;
-        $S = $this->preparePositiveInteger($S);
-        $Sl = \mb_strlen($S, '8bit') / 2;
-        $der = \pack(
-            'H*',
-            '30'.($Rl + $Sl + 4 > 128 ? '81' : '').\dechex($Rl + $Sl + 4)
-            .'02'.\dechex($Rl).$R
-            .'02'.\dechex($Sl).$S
-        );
-
-        return $der;
-    }
-
-    /**
      * Convert a DER signature into ECDSA.
      *
      * The code is a copy/paste from another lib (web-token/jwt-core) which is not compatible with php <= 7.0

--- a/src/Ssl/composer.json
+++ b/src/Ssl/composer.json
@@ -35,6 +35,7 @@
         "php": ">=5.5.0",
         "ext-hash": "*",
         "ext-openssl": "*",
+        "lib-openssl": ">=0.9.8",
         "webmozart/assert": "^1.0"
     },
     "require-dev": {

--- a/src/Ssl/composer.json
+++ b/src/Ssl/composer.json
@@ -9,6 +9,8 @@
         "https",
         "acmephp",
         "ssl",
+        "RSA",
+        "ECDSA",
         "openssl",
         "CSR",
         "x509"

--- a/tests/Ssl/Generator/KeyPairGeneratorTest.php
+++ b/tests/Ssl/Generator/KeyPairGeneratorTest.php
@@ -11,6 +11,8 @@
 
 namespace Tests\AcmePhp\Ssl\Generator;
 
+use AcmePhp\Ssl\Generator\DhKey\DhKeyOption;
+use AcmePhp\Ssl\Generator\DsaKey\DsaKeyOption;
 use AcmePhp\Ssl\Generator\EcKey\EcKeyOption;
 use AcmePhp\Ssl\Generator\KeyPairGenerator;
 use AcmePhp\Ssl\Generator\RsaKey\RsaKeyOption;
@@ -51,6 +53,38 @@ class KeyPairGeneratorTest extends TestCase
         $details = openssl_pkey_get_details($result->getPrivateKey()->getResource());
         $this->assertEquals(1024, $details['bits']);
         $this->assertArrayHasKey('rsa', $details);
+    }
+
+    public function test generateKeyPair generate random instance of KeyPair using DH()
+    {
+        $result = $this->service->generateKeyPair(new DhKeyOption(
+            'dcf93a0b883972ec0e19989ac5a2ce310e1d37717e8d9571bb7623731866e61ef75a2e27898b057f9891c2e27a639c3f29b60814581cd3b2ca3986d2683705577d45c2e7e52dc81c7a171876e5cea74b1448bfdfaf18828efd2519f14e45e3826634af1949e5b535cc829a483b8a76223e5d490a257f05bdff16f2fb22c583ab',
+            '02'
+        ));
+
+        $this->assertInstanceOf(KeyPair::class, $result);
+        $this->assertContains('-----BEGIN PUBLIC KEY-----', $result->getPublicKey()->getPEM());
+        $this->assertContains('-----BEGIN PRIVATE KEY-----', $result->getPrivateKey()->getPEM());
+        $this->assertInternalType('resource', $result->getPublicKey()->getResource());
+        $this->assertInternalType('resource', $result->getPrivateKey()->getResource());
+
+        $details = openssl_pkey_get_details($result->getPrivateKey()->getResource());
+        $this->assertArrayHasKey('dh', $details);
+    }
+
+    public function test generateKeyPair generate random instance of KeyPair using DSA()
+    {
+        $result = $this->service->generateKeyPair(new DsaKeyOption(1024));
+
+        $this->assertInstanceOf(KeyPair::class, $result);
+        $this->assertContains('-----BEGIN PUBLIC KEY-----', $result->getPublicKey()->getPEM());
+        $this->assertContains('-----BEGIN PRIVATE KEY-----', $result->getPrivateKey()->getPEM());
+        $this->assertInternalType('resource', $result->getPublicKey()->getResource());
+        $this->assertInternalType('resource', $result->getPrivateKey()->getResource());
+
+        $details = openssl_pkey_get_details($result->getPrivateKey()->getResource());
+        $this->assertEquals(1024, $details['bits']);
+        $this->assertArrayHasKey('dsa', $details);
     }
 
     /**

--- a/tests/Ssl/Generator/KeyPairGeneratorTest.php
+++ b/tests/Ssl/Generator/KeyPairGeneratorTest.php
@@ -11,7 +11,9 @@
 
 namespace Tests\AcmePhp\Ssl\Generator;
 
+use AcmePhp\Ssl\Generator\EcKey\EcKeyOption;
 use AcmePhp\Ssl\Generator\KeyPairGenerator;
+use AcmePhp\Ssl\Generator\RsaKey\RsaKeyOption;
 use AcmePhp\Ssl\KeyPair;
 use PHPUnit\Framework\TestCase;
 
@@ -27,14 +29,46 @@ class KeyPairGeneratorTest extends TestCase
         $this->service = new KeyPairGenerator();
     }
 
-    public function test generateKeyPair generate random instance of KeyPair()
+    /**
+     * @group legacy
+     */
+    public function test generateKeyPair supports keysize()
     {
         $result = $this->service->generateKeyPair(1024);
+        $this->assertInstanceOf(KeyPair::class, $result);
+    }
+
+    public function test generateKeyPair generate random instance of KeyPair()
+    {
+        $result = $this->service->generateKeyPair(new RsaKeyOption(1024));
 
         $this->assertInstanceOf(KeyPair::class, $result);
         $this->assertContains('-----BEGIN PUBLIC KEY-----', $result->getPublicKey()->getPEM());
         $this->assertContains('-----BEGIN PRIVATE KEY-----', $result->getPrivateKey()->getPEM());
         $this->assertInternalType('resource', $result->getPublicKey()->getResource());
         $this->assertInternalType('resource', $result->getPrivateKey()->getResource());
+
+        $details = openssl_pkey_get_details($result->getPrivateKey()->getResource());
+        $this->assertEquals(1024, $details['bits']);
+        $this->assertArrayHasKey('rsa', $details);
+    }
+
+    /**
+     * @requires PHP 7.1
+     */
+    public function test generateKeyPair generate random instance of KeyPair using EC()
+    {
+        $result = $this->service->generateKeyPair(new EcKeyOption('secp112r1'));
+
+        $this->assertInstanceOf(KeyPair::class, $result);
+        $this->assertContains('-----BEGIN PUBLIC KEY-----', $result->getPublicKey()->getPEM());
+        $this->assertContains('-----BEGIN EC PRIVATE KEY-----', $result->getPrivateKey()->getPEM());
+        $this->assertInternalType('resource', $result->getPublicKey()->getResource());
+        $this->assertInternalType('resource', $result->getPrivateKey()->getResource());
+
+        $details = openssl_pkey_get_details($result->getPrivateKey()->getResource());
+        $this->assertEquals(112, $details['bits']);
+        $this->assertArrayHasKey('ec', $details);
+        $this->assertEquals('secp112r1', $details['ec']['curve_name']);
     }
 }

--- a/tests/Ssl/Signer/CertificateRequestSignerTest.php
+++ b/tests/Ssl/Signer/CertificateRequestSignerTest.php
@@ -14,6 +14,7 @@ namespace Tests\AcmePhp\Ssl\Signer;
 use AcmePhp\Ssl\CertificateRequest;
 use AcmePhp\Ssl\DistinguishedName;
 use AcmePhp\Ssl\Generator\KeyPairGenerator;
+use AcmePhp\Ssl\Generator\RsaKey\RsaKeyOption;
 use AcmePhp\Ssl\Signer\CertificateRequestSigner;
 use PHPUnit\Framework\TestCase;
 
@@ -35,7 +36,7 @@ class CertificateRequestSignerTest extends TestCase
             'acmephp.com',
             'FR', 'france', 'Paris', 'acme', 'IT', 'qa@acmephp.com', []
         );
-        $dummyKeyPair = (new KeyPairGenerator())->generateKeyPair(1024);
+        $dummyKeyPair = (new KeyPairGenerator())->generateKeyPair(new RsaKeyOption(1024));
 
         $result = $this->service->signCertificateRequest(
             new CertificateRequest($dummyDistinguishedName, $dummyKeyPair)
@@ -63,7 +64,7 @@ class CertificateRequestSignerTest extends TestCase
         $dummyDistinguishedName = new DistinguishedName(
             'acmephp.com'
         );
-        $dummyKeyPair = (new KeyPairGenerator())->generateKeyPair(1024);
+        $dummyKeyPair = (new KeyPairGenerator())->generateKeyPair(new RsaKeyOption(1024));
 
         $result = $this->service->signCertificateRequest(
             new CertificateRequest($dummyDistinguishedName, $dummyKeyPair)
@@ -85,7 +86,7 @@ class CertificateRequestSignerTest extends TestCase
             'acmephp.com',
             'FR', 'france', 'Paris', 'acme', 'IT', 'qa@acmephp.com', ['www.acmephp.com']
         );
-        $dummyKeyPair = (new KeyPairGenerator())->generateKeyPair(1024);
+        $dummyKeyPair = (new KeyPairGenerator())->generateKeyPair(new RsaKeyOption(1024));
 
         $result = $this->service->signCertificateRequest(
             new CertificateRequest($dummyDistinguishedName, $dummyKeyPair)

--- a/tests/Ssl/Signer/DataSignerTest.php
+++ b/tests/Ssl/Signer/DataSignerTest.php
@@ -11,7 +11,10 @@
 
 namespace Tests\AcmePhp\Ssl\Signer;
 
-use AcmePhp\Ssl\PrivateKey;
+use AcmePhp\Ssl\Generator\EcKey\EcKeyGenerator;
+use AcmePhp\Ssl\Generator\EcKey\EcKeyOption;
+use AcmePhp\Ssl\Generator\RsaKey\RsaKeyGenerator;
+use AcmePhp\Ssl\Generator\RsaKey\RsaKeyOption;
 use AcmePhp\Ssl\Signer\DataSigner;
 use PHPUnit\Framework\TestCase;
 
@@ -29,70 +32,29 @@ class DataSignerTest extends TestCase
 
     public function test signData returns a signature()
     {
-        $privateKey = new PrivateKey('-----BEGIN PRIVATE KEY-----
-MIIJQgIBADANBgkqhkiG9w0BAQEFAASCCSwwggkoAgEAAoICAQDH3IKV8sJZZHGd
-Q0vUN9GHJACixg8N1wFpUe763HmnWwiyCFHK9YjOfxkDSRK+2lP72Ns+RTBwtM8s
-ZbRIALwe2fjMWGFIvKuHOcls5Lt6h4UXeriboKRWpnznpK9mziwm4fM6lJ7NBenD
-gv2WLYKjzr/cl37NrV6zJzrQ+vPDKfOEtjhrkVgTwSVTi6+k9j6udtfmpI+nUHpS
-PkLFbK3dBEsXA+E1jf7VhC1Vru2+lPZy0N7Y4D5JU+rYAe7vAbIX88qHarh9O6gh
-GSgWnlVdGaMbHE0NAMsDWvzx4p4YiV9/oX9ja428/HOQtL/X6uUHArE8DPV9uNi3
-Kd4Zn0ElYOKg0ThPs6k8MLe/yquN2tj5brhUyMh9LxMFDuQFd/XYc6g8olv8Xebk
-GcZCwoIGA0OpKM8hYmsKS1zqJ/tfdkbIK91HaSEw+AJ41oHag7uPMI51ol7LRV/B
-5o88Wl3GsRToCNYuWRG962TZhvWwPYTcCHRVn7+noDTo6jej/Lx3LR3LYI7wCbUT
-tcPxbclT4M/CsQ4g4UGzqU7p1lnnJeth8TJTdE4DabmkYYj2Sztg96qsmOvDfbi5
-TBE9yGIaS21ug4MeMGzvD/TriII1KH2cS6smMdoE4224gY1d228XQL+Ii8G/6AHu
-2+b88rnOhAvbJaVI3/WlEoKF9K7pfwIDAQABAoICAFe7FBd+WJGk5bqCr+aYGgGY
-bC8HgdQxbQ0uShkUbtJnw4li3YSaA1OhtvkaOoBMllEXACZ1eK4AsHBstJZmvC1O
-wUfyA8JKD4FsfF6wiRtgIawM0rx956Whr3J/d/9IwVjQFlTAqHSXA+YuueISWCZP
-uyi514+xasB5l/fkMNyaraqz0lBlnKQPRLNHvfJLpXgv8tXrpqNrUEaJzgWbjzZV
-jCCuM02u5w4S11OlVfcyrHv589h/ltfZXl0zfA6uT97zxRNsZU+TwFnHETHcjtwv
-RMnBwpDSqErwxdfoAj4DD0iXO7QIok8zAgejUBMXqTFKnUIe7iQh3/+HAVd98LoQ
-SW+/I/uYY5vl+s8e1MEl7I+se9DNYJzAEyHxrpNHJy8DvkKk2lxStPzbluJ45kgN
-0up0JsHwA8A5EsvicAP2Zwk51ksAq1bLf8zW08kCdsDK83qvLtLF3rp2T/O/jjf/
-WcrKIguzvekMBBNAoQVKX3yCLGHUUELXQcAbrJyHtG5aPrzGSvToI52/L4gf6DZL
-j+HFHBNLBjYlk1tOMzleqOebL3kxAFqFJjs6whBiTnIJn0QxKVaQPgMi/tKQ6nWR
-XefXUqCkosxSBJvEzqIoWj0EmFvzczFrn/873EiBsySxmmvqBX06632V0cpyu4Cs
-+pr/qisf5Eaa1P7oP9gBAoIBAQD3hboPrbiXSqficnmq9kzbQ8dKtmtlfzBrgFkf
-0nzaCBTRpYbLluQe+9hSb6JFgNjcPBtguI0bzvI5X4XpPnYluIIa5oWV91Lz8MU+
-gCCew6Geu5g363cOIFBRveRjb59uTutJ1GigM1BI/JywwhDU++6hoyp1XM03hCKM
-mHZG2tmlcH9SRG8fO9KqqS12AUd9xcTPRqsUwT62LULZTuf2pjIYOlSNIfSZkRBY
-1ZfHnVGzpsNZ+Jd1BXrFiqVEdmTevGQbciOKJi63UswLWFGgRIDO0AClDKdZUnaK
-fFxc1V8HkWf5FF0DMlMF7gZpw2ivnz/TrtWpgS9yN/R6uxjhAoIBAQDOtORmz9WB
-d3Uudce/I73FXp1FyrE1SOzLHsGIaFdx1xIhLjjNHVwv9N/HKablt/v+o2MBLAZD
-JFmX8WMzqzMCt9oiVq2v8Gvoh/IKMLaQZYgt+hyb6g6MzhscjlXVT53ippLHuGT+
-jLsAQvDDgwSuiyTqTCZRhaw19lVWrKG2TMYexLo2qIRyp+cItVNZmALQVQzJl/kC
-qgWA25fh3INwddNDjHWk4VkWM/cfOInCRnT+8vy/ipiVwioDhLIA9QxQU7MUrj0T
-mArEsRe3cnDajRBkdg09gQGSformlxbemoRayjLCE9Xu/Bkecx+AFPqvKZ3vGs2t
-WRCLQhTGkG5fAoIBACvMySDvH8P93PlwQmFjVjRSqRhqcVSzjhDn1F2SNK+sUGrM
-vK6YE+P7ssrboD5mT3mhVULnRWkPVMOcSKj+eY+xN6yk8CyaaF5sU6r8p0kQ2y+o
-iIYUr6ubQjtEu/5wiSjO5EnbQWxfyCwyL1QD81CNCCwoIGJGOrZBNo/khsGBBpSE
-9LLNE1DWmC/E4huInGsALRR0r99rVrqMBdFIajm2LRUmdUHIKW1nQxpFKaeUChod
-P2JTYBHAF3qPTzFvNehIM/q7Vtiiaw/boem8Bi2zEYwHOKX8ODzRH9LfsMRoqXlA
-XMKxvMfNBu38sbvTbVnudy/xNzPYfVnb1vJE22ECggEBAJeWJs2S6tNIBIJu025D
-yr58FUACVhRqh2SqCGl9g2szutLkb7lUJ6/vl1AaJo/ebgmeTlOksm74sE9yMTrJ
-+N2scGawRC17VdcwIvsAIFIic0ysV+CrM8Jkv5Mgeqe0/Gcjmw6mFkJqeBTIAoKO
-iZdq6UZ9U7iDG/hyzsCCVxE2mjAkOx8sU/01ToOfXiGdDas0Q+1u6qjegKyv3WFA
-co+9iJHH5tpkfA2BTF/z+WqketYg4eOhwyZIPsFXxaZYDpC14OVwpc/Bt1vpNyhL
-36EWxAe4XxtUiQ+ih0B1Wssia5+dGr4jB8d7zvv6lwY53GEqVuzrLhxK7YwCiPPZ
-JWcCggEAUSRCR/CQfu2uqxNDdaUAycd5n+4TdPvM/uU19U7hnAMgjjMzli4evo6E
-gV2YJOxiU1rhnmT8eqEOjtK5fQmeoTeDINYzNy69RKQ1LJHe9DPweDU9xT9koUcX
-t0xorLCRbXVWgF8c4uVd7InRbHM611xa4CkWYC7wmCffrszOSBJZtQVinN4RmlvP
-iGK6mZDSwgi3zAKkSK5jaRqPtztIwcHLPXLIiSKI6Dc3IuGYU1lf1n9RWPi39EdV
-khMBuAxgunyQC+UcviTry1OlOI95e/bZNgVvyTyg4/TbFyn1+1QLNeMtqJE5n5GJ
-jIsyJPXjdAhzAparBWwYzxywy+8PMA==
------END PRIVATE KEY-----
-');
+        $privateRsaKey = (new RsaKeyGenerator())->generatePrivateKey(new RsaKeyOption());
 
-        $this->assertEquals(512, \strlen($this->service->signData('foo', $privateKey)));
-        $this->assertEquals(512, \strlen($this->service->signData('foo', $privateKey, OPENSSL_ALGO_SHA256)));
-        $this->assertEquals(512, \strlen($this->service->signData('foo', $privateKey, OPENSSL_ALGO_SHA512)));
+        $this->assertEquals(512, \strlen($this->service->signData('foo', $privateRsaKey)));
+        $this->assertEquals(512, \strlen($this->service->signData('foo', $privateRsaKey, OPENSSL_ALGO_SHA256)));
+        $this->assertEquals(512, \strlen($this->service->signData('foo', $privateRsaKey, OPENSSL_ALGO_SHA384)));
+        $this->assertEquals(512, \strlen($this->service->signData('foo', $privateRsaKey, OPENSSL_ALGO_SHA512)));
         $this->assertEquals(
-            $this->service->signData('foo', $privateKey),
-            $this->service->signData('foo', $privateKey, OPENSSL_ALGO_SHA256)
+            $this->service->signData('foo', $privateRsaKey),
+            $this->service->signData('foo', $privateRsaKey, OPENSSL_ALGO_SHA256)
         );
         $this->assertNotEquals(
-            $this->service->signData('foo', $privateKey, OPENSSL_ALGO_SHA256),
-            $this->service->signData('foo', $privateKey, OPENSSL_ALGO_SHA512)
+            $this->service->signData('foo', $privateRsaKey, OPENSSL_ALGO_SHA256),
+            $this->service->signData('foo', $privateRsaKey, OPENSSL_ALGO_SHA512)
         );
+    }
+
+    /**
+     * @requires PHP 7.1
+     */
+    public function test signData returns a signature for ec keys()
+    {
+        $this->assertEquals(64, \strlen($this->service->signData('foo', (new EcKeyGenerator())->generatePrivateKey(new EcKeyOption('prime256v1')), OPENSSL_ALGO_SHA256, DataSigner::FORMAT_ECDSA)));
+        $this->assertEquals(96, \strlen($this->service->signData('foo', (new EcKeyGenerator())->generatePrivateKey(new EcKeyOption('secp384r1')), OPENSSL_ALGO_SHA384, DataSigner::FORMAT_ECDSA)));
+        $this->assertEquals(132, \strlen($this->service->signData('foo', (new EcKeyGenerator())->generatePrivateKey(new EcKeyOption('secp521r1')), OPENSSL_ALGO_SHA512, DataSigner::FORMAT_ECDSA)));
     }
 }

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -27,4 +27,4 @@ p9BI7gVKtWSZYegicA==
 echo "$cert" > "$tempfile"
 trap "{ rm -f $tempfile; }" EXIT
 
-SYMFONY_DEPRECATIONS_HELPER=disabled php -d curl.cainfo="$tempfile" ./vendor/bin/simple-phpunit $*
+php -d curl.cainfo="$tempfile" ./vendor/bin/simple-phpunit $*


### PR DESCRIPTION
Fixes #23 

This PR contains 1 BC break `DataSigner::signData` now takes a string alg (RS256, ES384, ...) instead of a int (OPENSSL_ALGO_SHA256). bacause the the method `openssl_sign` returns a format PKCS, wereas EC256 expect a specific format.
