### PR TITLE
Fix exception constructor

### DIFF
--- a/src/Core/Exception/AcmeDnsResolutionException.php
+++ b/src/Core/Exception/AcmeDnsResolutionException.php
@@ -18,6 +18,6 @@ class AcmeDnsResolutionException extends AcmeCoreException
 {
     public function __construct($message, \Exception $previous = null)
     {
-        parent::__construct(null === $message ? 'An exception was thrown during resolution of DNS' : $message, $previous);
+        parent::__construct(null === $message ? 'An exception was thrown during resolution of DNS' : $message, 0, $previous);
     }
 }


### PR DESCRIPTION
because `class AcmeDnsResolutionException extends AcmeCoreException` and `class AcmeCoreException extends \RuntimeException`