### PR TITLE
Free the resource after reading

### DIFF
--- a/src/Ssl/Parser/KeyParser.php
+++ b/src/Ssl/Parser/KeyParser.php
@@ -39,6 +39,7 @@ class KeyParser
         }
 
         $rawData = openssl_pkey_get_details($resource);
+        openssl_free_key($resource);
 
         if (!\is_array($rawData)) {
             throw new KeyParsingException(sprintf('Fail to parse key with error: %s', openssl_error_string()));

--- a/src/Ssl/PrivateKey.php
+++ b/src/Ssl/PrivateKey.php
@@ -38,9 +38,12 @@ class PrivateKey extends Key
      */
     public function getPublicKey()
     {
-        if (!$details = openssl_pkey_get_details($this->getResource())) {
+        $resource = $this->getResource();
+        if (!$details = openssl_pkey_get_details($resource)) {
             throw new KeyFormatException(sprintf('Failed to extract public key: %s', openssl_error_string()));
         }
+
+        openssl_free_key($resource);
 
         return new PublicKey($details['key']);
     }

--- a/src/Ssl/Signer/CertificateRequestSigner.php
+++ b/src/Ssl/Signer/CertificateRequestSigner.php
@@ -90,6 +90,8 @@ EOL;
                 ]
             );
 
+            openssl_free_key($resource);
+
             if (!$csr) {
                 throw new CSRSigningException(
                     sprintf('OpenSSL CSR signing failed with error: %s', openssl_error_string())

--- a/src/Ssl/Signer/DataSigner.php
+++ b/src/Ssl/Signer/DataSigner.php
@@ -39,11 +39,14 @@ class DataSigner
     {
         Assert::oneOf($format, [self::FORMAT_ECDSA, self::FORMAT_DER], 'The format %s to sign request does not exists. Available format: %s');
 
-        if (!openssl_sign($data, $signature, $privateKey->getResource(), $algorithm)) {
+        $resource = $privateKey->getResource();
+        if (!openssl_sign($data, $signature, $resource, $algorithm)) {
             throw new DataSigningException(
                 sprintf('OpenSSL data signing failed with error: %s', openssl_error_string())
             );
         }
+
+        openssl_free_key($resource);
 
         switch ($format) {
             case self::FORMAT_DER:


### PR DESCRIPTION
The openssl resource needs to be released after reading to prevent leaking memory.