### PR TITLE
Adding Gandi.Net DNS solver class

### DIFF
--- a/src/Cli/Command/AuthorizeCommand.php
+++ b/src/Cli/Command/AuthorizeCommand.php
@@ -32,7 +32,7 @@ class AuthorizeCommand extends AbstractCommand
     {
         $this->setName('authorize')
             ->setDefinition([
-                new InputOption('solver', 's', InputOption::VALUE_REQUIRED, 'The type of challenge solver to use (available: http, dns, route53)', 'http'),
+                new InputOption('solver', 's', InputOption::VALUE_REQUIRED, 'The type of challenge solver to use (available: http, dns, route53, gandi)', 'http'),
                 new InputArgument('domains', InputArgument::IS_ARRAY | InputArgument::REQUIRED, 'List of domains to ask an authorization for'),
             ])
             ->setDescription('Ask the ACME server for an authorization token to check you are the owner of a domain')

--- a/src/Cli/Command/CheckCommand.php
+++ b/src/Cli/Command/CheckCommand.php
@@ -34,7 +34,7 @@ class CheckCommand extends AbstractCommand
     {
         $this->setName('check')
             ->setDefinition([
-                new InputOption('solver', 's', InputOption::VALUE_REQUIRED, 'The type of challenge solver to use (available: http, dns, route53)', 'http'),
+                new InputOption('solver', 's', InputOption::VALUE_REQUIRED, 'The type of challenge solver to use (available: http, dns, route53, gandi)', 'http'),
                 new InputOption('no-test', 't', InputOption::VALUE_NONE, 'Whether or not internal tests should be disabled'),
                 new InputArgument('domains', InputArgument::IS_ARRAY | InputArgument::REQUIRED, 'The list of domains to check the authorization for'),
             ])

--- a/src/Cli/Resources/services.xml
+++ b/src/Cli/Resources/services.xml
@@ -182,6 +182,12 @@
             <call method="setLogger"><argument type="service" id="cli_logger"/></call>
             <tag name="acmephp.challenge_solver" alias="route53" />
         </service>
+        <service id="acmephp.challenge_solver.gandi" class="AcmePhp\Core\Challenge\Dns\GandiSolver" public="false">
+            <argument type="service" id="challenge_extractor.dns" />
+            <argument type="service" id="http.raw_client" />
+            <call method="setLogger"><argument type="service" id="cli_logger"/></call>
+            <tag name="acmephp.challenge_solver" alias="gandi" />
+        </service>
         <service id="acmephp.challenge_solver.locator" class="Symfony\Component\DependencyInjection\ServiceLocator">
             <argument type="collection"/>
             <tag name="acmephp.service_locator" tag="acmephp.challenge_solver"/>

--- a/src/Core/Challenge/Dns/GandiSolver.php
+++ b/src/Core/Challenge/Dns/GandiSolver.php
@@ -1,0 +1,197 @@
+<?php
+
+/*
+ * This file is part of the Acme PHP project.
+ *
+ * (c) Titouan Galopin <galopintitouan@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace AcmePhp\Core\Challenge\Dns;
+
+use AcmePhp\Core\Challenge\ConfigurableServiceInterface;
+use AcmePhp\Core\Challenge\MultipleChallengesSolverInterface;
+use AcmePhp\Core\Protocol\AuthorizationChallenge;
+use GuzzleHttp\Client;
+use GuzzleHttp\ClientInterface;
+use Psr\Log\LoggerAwareTrait;
+use Psr\Log\NullLogger;
+use Webmozart\Assert\Assert;
+
+/**
+ * ACME DNS solver with automate configuration of a Gandi.Net.
+ *
+ * @author Alexander Obuhovich <aik.bold@gmail.com>
+ */
+class GandiSolver implements MultipleChallengesSolverInterface, ConfigurableServiceInterface
+{
+    use LoggerAwareTrait;
+    /**
+     * @var DnsDataExtractor
+     */
+    private $extractor;
+
+    /**
+     * @var ClientInterface
+     */
+    private $client;
+
+    /**
+     * @var array
+     */
+    private $cacheZones;
+
+    /**
+     * @var string
+     */
+    private $apiKey;
+
+    /**
+     * @param DnsDataExtractor $extractor
+     * @param ClientInterface    $client
+     */
+    public function __construct(
+        DnsDataExtractor $extractor = null,
+        ClientInterface $client = null
+    ) {
+        $this->extractor = null === $extractor ? new DnsDataExtractor() : $extractor;
+        $this->client = null === $client ? new Client() : $client;
+        $this->logger = new NullLogger();
+    }
+
+    /**
+     * Configure the service with a set of configuration.
+     *
+     * @param array $config
+     */
+    public function configure(array $config)
+    {
+        $this->apiKey = $config['api_key'];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supports(AuthorizationChallenge $authorizationChallenge)
+    {
+        return 'dns-01' === $authorizationChallenge->getType();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function solve(AuthorizationChallenge $authorizationChallenge)
+    {
+        return $this->solveAll([$authorizationChallenge]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function solveAll(array $authorizationChallenges)
+    {
+        Assert::allIsInstanceOf($authorizationChallenges, AuthorizationChallenge::class);
+
+        foreach ($authorizationChallenges as $authorizationChallenge) {
+            $topLevelDomain = $this->getTopLevelDomain($authorizationChallenge->getDomain());
+            $recordName = $this->extractor->getRecordName($authorizationChallenge);
+            $recordValue = $this->extractor->getRecordValue($authorizationChallenge);
+
+            $subDomain = \str_replace('.' . $topLevelDomain . '.', '', $recordName);
+
+            $this->client->request(
+                'PUT',
+                'https://dns.api.gandi.net/api/v5/domains/' . $topLevelDomain . '/records/' . $subDomain . '/TXT',
+                [
+                    'headers' => [
+                        'X-Api-Key' => $this->apiKey,
+                    ],
+                    'json' => [
+                        'rrset_type' => 'TXT',
+                        'rrset_ttl' => 600,
+                        'rrset_name' => $subDomain,
+                        'rrset_values' => [$recordValue]
+                    ]
+                ]
+            );
+
+            // TODO: Validate that record was set.
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function cleanup(AuthorizationChallenge $authorizationChallenge)
+    {
+        return $this->cleanupAll([$authorizationChallenge]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function cleanupAll(array $authorizationChallenges)
+    {
+        Assert::allIsInstanceOf($authorizationChallenges, AuthorizationChallenge::class);
+
+        foreach ($authorizationChallenges as $authorizationChallenge) {
+            $topLevelDomain = $this->getTopLevelDomain($authorizationChallenge->getDomain());
+            $recordName = $this->extractor->getRecordName($authorizationChallenge);
+
+            $subDomain = \str_replace('.' . $topLevelDomain . '.', '', $recordName);
+
+            $this->client->request(
+                'DELETE',
+                'https://dns.api.gandi.net/api/v5/domains/' . $topLevelDomain . '/records/' . $subDomain . '/TXT',
+                [
+                    'headers' => [
+                        'X-Api-Key' => $this->apiKey,
+                    ],
+                ]
+            );
+        }
+    }
+
+    /**
+     * @param string $domain
+     *
+     * @return string
+     */
+    protected function getTopLevelDomain($domain)
+    {
+        return \implode('.', \array_slice(\explode('.', $domain), -2));
+    }
+
+
+    /**
+     * @param AuthorizationChallenge[] $authorizationChallenges
+     *
+     * @return AuthorizationChallenge[][]
+     */
+    private function groupAuthorizationChallengesPerDomain(array $authorizationChallenges)
+    {
+        $groups = [];
+        foreach ($authorizationChallenges as $authorizationChallenge) {
+            $groups[$authorizationChallenge->getDomain()][] = $authorizationChallenge;
+        }
+
+        return $groups;
+    }
+
+    /**
+     * @param AuthorizationChallenge[] $authorizationChallenges
+     *
+     * @return AuthorizationChallenge[][]
+     */
+    private function groupAuthorizationChallengesPerRecordName(array $authorizationChallenges)
+    {
+        $groups = [];
+        foreach ($authorizationChallenges as $authorizationChallenge) {
+            $groups[$this->extractor->getRecordName($authorizationChallenge)][] = $authorizationChallenge;
+        }
+
+        return $groups;
+    }
+}

--- a/src/Core/Challenge/Dns/GandiSolver.php
+++ b/src/Core/Challenge/Dns/GandiSolver.php
@@ -116,8 +116,6 @@ class GandiSolver implements MultipleChallengesSolverInterface, ConfigurableServ
                     ],
                 ]
             );
-
-            // TODO: Validate that record was set.
         }
     }
 
@@ -162,35 +160,5 @@ class GandiSolver implements MultipleChallengesSolverInterface, ConfigurableServ
     protected function getTopLevelDomain($domain)
     {
         return \implode('.', \array_slice(\explode('.', $domain), -2));
-    }
-
-    /**
-     * @param AuthorizationChallenge[] $authorizationChallenges
-     *
-     * @return AuthorizationChallenge[][]
-     */
-    private function groupAuthorizationChallengesPerDomain(array $authorizationChallenges)
-    {
-        $groups = [];
-        foreach ($authorizationChallenges as $authorizationChallenge) {
-            $groups[$authorizationChallenge->getDomain()][] = $authorizationChallenge;
-        }
-
-        return $groups;
-    }
-
-    /**
-     * @param AuthorizationChallenge[] $authorizationChallenges
-     *
-     * @return AuthorizationChallenge[][]
-     */
-    private function groupAuthorizationChallengesPerRecordName(array $authorizationChallenges)
-    {
-        $groups = [];
-        foreach ($authorizationChallenges as $authorizationChallenge) {
-            $groups[$this->extractor->getRecordName($authorizationChallenge)][] = $authorizationChallenge;
-        }
-
-        return $groups;
     }
 }

--- a/src/Core/Challenge/Dns/GandiSolver.php
+++ b/src/Core/Challenge/Dns/GandiSolver.php
@@ -50,7 +50,7 @@ class GandiSolver implements MultipleChallengesSolverInterface, ConfigurableServ
 
     /**
      * @param DnsDataExtractor $extractor
-     * @param ClientInterface    $client
+     * @param ClientInterface  $client
      */
     public function __construct(
         DnsDataExtractor $extractor = null,
@@ -99,11 +99,11 @@ class GandiSolver implements MultipleChallengesSolverInterface, ConfigurableServ
             $recordName = $this->extractor->getRecordName($authorizationChallenge);
             $recordValue = $this->extractor->getRecordValue($authorizationChallenge);
 
-            $subDomain = \str_replace('.' . $topLevelDomain . '.', '', $recordName);
+            $subDomain = \str_replace('.'.$topLevelDomain.'.', '', $recordName);
 
             $this->client->request(
                 'PUT',
-                'https://dns.api.gandi.net/api/v5/domains/' . $topLevelDomain . '/records/' . $subDomain . '/TXT',
+                'https://dns.api.gandi.net/api/v5/domains/'.$topLevelDomain.'/records/'.$subDomain.'/TXT',
                 [
                     'headers' => [
                         'X-Api-Key' => $this->apiKey,
@@ -112,8 +112,8 @@ class GandiSolver implements MultipleChallengesSolverInterface, ConfigurableServ
                         'rrset_type' => 'TXT',
                         'rrset_ttl' => 600,
                         'rrset_name' => $subDomain,
-                        'rrset_values' => [$recordValue]
-                    ]
+                        'rrset_values' => [$recordValue],
+                    ],
                 ]
             );
 
@@ -140,11 +140,11 @@ class GandiSolver implements MultipleChallengesSolverInterface, ConfigurableServ
             $topLevelDomain = $this->getTopLevelDomain($authorizationChallenge->getDomain());
             $recordName = $this->extractor->getRecordName($authorizationChallenge);
 
-            $subDomain = \str_replace('.' . $topLevelDomain . '.', '', $recordName);
+            $subDomain = \str_replace('.'.$topLevelDomain.'.', '', $recordName);
 
             $this->client->request(
                 'DELETE',
-                'https://dns.api.gandi.net/api/v5/domains/' . $topLevelDomain . '/records/' . $subDomain . '/TXT',
+                'https://dns.api.gandi.net/api/v5/domains/'.$topLevelDomain.'/records/'.$subDomain.'/TXT',
                 [
                     'headers' => [
                         'X-Api-Key' => $this->apiKey,
@@ -163,7 +163,6 @@ class GandiSolver implements MultipleChallengesSolverInterface, ConfigurableServ
     {
         return \implode('.', \array_slice(\explode('.', $domain), -2));
     }
-
 
     /**
      * @param AuthorizationChallenge[] $authorizationChallenges

--- a/tests/Core/Challenge/Dns/GandiSolverTest.php
+++ b/tests/Core/Challenge/Dns/GandiSolverTest.php
@@ -64,8 +64,8 @@ class GandiSolverTest extends TestCase
                     'rrset_type' => 'TXT',
                     'rrset_ttl' => 600,
                     'rrset_name' => '_acme-challenge.sub-domain',
-                    'rrset_values' => ['record_value']
-                ]
+                    'rrset_values' => ['record_value'],
+                ],
             ]
         )->shouldBeCalled();
 

--- a/tests/Core/Challenge/Dns/GandiSolverTest.php
+++ b/tests/Core/Challenge/Dns/GandiSolverTest.php
@@ -1,0 +1,105 @@
+<?php
+
+/*
+ * This file is part of the Acme PHP project.
+ *
+ * (c) Titouan Galopin <galopintitouan@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\AcmePhp\Core\Challenge\Dns;
+
+use AcmePhp\Core\Challenge\Dns\DnsDataExtractor;
+use AcmePhp\Core\Challenge\Dns\GandiSolver;
+use AcmePhp\Core\Protocol\AuthorizationChallenge;
+use GuzzleHttp\ClientInterface;
+use PHPUnit\Framework\TestCase;
+
+class GandiSolverTest extends TestCase
+{
+    public function testSupports()
+    {
+        $typeDns = 'dns-01';
+        $typeHttp = 'http-01';
+
+        $mockExtractor = $this->prophesize(DnsDataExtractor::class);
+        $mockClient = $this->prophesize(ClientInterface::class);
+        $stubChallenge = $this->prophesize(AuthorizationChallenge::class);
+
+        $solver = new GandiSolver($mockExtractor->reveal(), $mockClient->reveal());
+
+        $stubChallenge->getType()->willReturn($typeDns);
+        $this->assertTrue($solver->supports($stubChallenge->reveal()));
+
+        $stubChallenge->getType()->willReturn($typeHttp);
+        $this->assertFalse($solver->supports($stubChallenge->reveal()));
+    }
+
+    public function testSolve()
+    {
+        $domain = 'sub-domain.bar.com';
+        $recordName = '_acme-challenge.sub-domain.bar.com.';
+        $recordValue = 'record_value';
+
+        $mockExtractor = $this->prophesize(DnsDataExtractor::class);
+        $mockClient = $this->prophesize(ClientInterface::class);
+        $stubChallenge = $this->prophesize(AuthorizationChallenge::class);
+
+        $solver = new GandiSolver($mockExtractor->reveal(), $mockClient->reveal());
+
+        $mockExtractor->getRecordName($stubChallenge->reveal())->willReturn($recordName);
+        $mockExtractor->getRecordValue($stubChallenge->reveal())->willReturn($recordValue);
+        $stubChallenge->getDomain()->willReturn($domain);
+
+        $mockClient->request(
+            'PUT',
+            'https://dns.api.gandi.net/api/v5/domains/bar.com/records/_acme-challenge.sub-domain/TXT',
+            [
+                'headers' => [
+                    'X-Api-Key' => 'stub',
+                ],
+                'json' => [
+                    'rrset_type' => 'TXT',
+                    'rrset_ttl' => 600,
+                    'rrset_name' => '_acme-challenge.sub-domain',
+                    'rrset_values' => ['record_value']
+                ]
+            ]
+        )->shouldBeCalled();
+
+        $solver->configure(['api_key' => 'stub']);
+        $solver->solve($stubChallenge->reveal());
+    }
+
+    public function testCleanup()
+    {
+        $domain = 'sub-domain.bar.com';
+        $recordName = '_acme-challenge.sub-domain.bar.com.';
+        $recordValue = 'record_value';
+
+        $mockExtractor = $this->prophesize(DnsDataExtractor::class);
+        $mockClient = $this->prophesize(ClientInterface::class);
+        $stubChallenge = $this->prophesize(AuthorizationChallenge::class);
+
+        $solver = new GandiSolver($mockExtractor->reveal(), $mockClient->reveal());
+
+        $mockExtractor->getRecordName($stubChallenge->reveal())->willReturn($recordName);
+        $mockExtractor->getRecordValue($stubChallenge->reveal())->willReturn($recordValue);
+        $stubChallenge->getDomain()->willReturn($domain);
+
+        $mockClient->request(
+            'DELETE',
+            'https://dns.api.gandi.net/api/v5/domains/bar.com/records/_acme-challenge.sub-domain/TXT',
+            [
+                'headers' => [
+                    'X-Api-Key' => 'stub',
+                ],
+            ]
+        )->shouldBeCalled();
+
+        $solver->configure(['api_key' => 'stub']);
+        $solver->cleanup($stubChallenge->reveal());
+    }
+}


### PR DESCRIPTION
Adds support for automatic challenge resolution using LiveDNS API of the Gandi.Net

How to use:

1. use https://acmephp.github.io/documentation/getting-started/2-obtain-certificate-easy.html as sample
2. instead of 
```yaml
solver:
    name: http-file
    adapter: ftp
```

do this:
```yaml
solver:
    name: gandi
    api_key: AAAAAAAAAAA
```

The API key is obtained from Gandi.Net Admin Panel.