### PR TITLE
Fix getIssuerCertificate return type

### DIFF
--- a/src/Ssl/Certificate.php
+++ b/src/Ssl/Certificate.php
@@ -64,7 +64,7 @@ class Certificate
     }
 
     /**
-     * @return Certificate
+     * @return Certificate|null
      */
     public function getIssuerCertificate()
     {


### PR DESCRIPTION
Method `getIssuerCertificate()` can return value null too. Null is default value in class constructor `public function __construct($certificatePEM, self $issuerCertificate = null)`.
