### PR TITLE
Rewind response body before generating summary for server errors

### DIFF
--- a/src/Core/Http/ServerErrorHandler.php
+++ b/src/Core/Http/ServerErrorHandler.php
@@ -59,6 +59,11 @@ class ServerErrorHandler
      */
     public static function getResponseBodySummary(ResponseInterface $response)
     {
+        // Rewind the stream if possible to allow re-reading for the summary.
+        if ($response->getBody()->isSeekable()) {
+            $response->getBody()->rewind();
+        }
+
         if (method_exists(RequestException::class, 'getResponseBodySummary')) {
             return RequestException::getResponseBodySummary($response);
         }

--- a/tests/Core/Http/ServerErrorHandlerTest.php
+++ b/tests/Core/Http/ServerErrorHandlerTest.php
@@ -77,6 +77,7 @@ class ServerErrorHandlerTest extends TestCase
         $this->assertInstanceOf(AcmeCoreServerException::class, $exception);
         $this->assertStringContainsString('non-ACME', $exception->getMessage());
         $this->assertStringContainsString('/foo/bar', $exception->getMessage());
+        $this->assertStringContainsString('Invalid JSON', $exception->getMessage());
     }
 
     public function testDefaultExceptionThrownNonAcmeJson()
@@ -91,5 +92,6 @@ class ServerErrorHandlerTest extends TestCase
         $this->assertInstanceOf(AcmeCoreServerException::class, $exception);
         $this->assertStringContainsString('non-ACME', $exception->getMessage());
         $this->assertStringContainsString('/foo/bar', $exception->getMessage());
+        $this->assertStringContainsString('"not":"acme"', $exception->getMessage());
     }
 }


### PR DESCRIPTION
We've been seeing AcmeCoreServerExceptions with a message like this:
`"A non-ACME 403 HTTP error occured on request "POST https://acme-v01.api.letsencrypt.org/acme/new-cert" (response body: " (truncated...)")"`

These exceptions are generated in `AcmePhp\Core\Http\ServerErrorHandler::createDefaultExceptionForResponse()`. By the time `AcmePhp\Core\Http\ServerErrorHandler::getResponseBodySummary()` is being run the response has already been read once, which is how the code knows to return a default exception. However, without rewinding the body the summary will always be empty.

I've added two assertions to the existing tests that confirm that the response body is now included in the exception message. Both assertions failed before adding the new code.