### PR TITLE
Support both Guzzle 6.x and 7.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "ext-openssl": "*",
         "lib-openssl": ">=0.9.8",
         "aws/aws-sdk-php": "^3.38",
-        "guzzlehttp/guzzle": "^6.0",
+        "guzzlehttp/guzzle": "^6.0|^7.0",
         "guzzlehttp/psr7": "^1.0",
         "league/flysystem": "^1.0.19",
         "league/flysystem-memory": "^1.0",

--- a/src/Core/composer.json
+++ b/src/Core/composer.json
@@ -32,7 +32,7 @@
         "ext-json": "*",
         "ext-openssl": "*",
         "acmephp/ssl": "^1.0",
-        "guzzlehttp/guzzle": "^6.0",
+        "guzzlehttp/guzzle": "^6.0|^7.0",
         "guzzlehttp/psr7": "^1.0",
         "psr/http-message": "^1.0",
         "psr/log": "^1.0",


### PR DESCRIPTION
I use AcmePHP Core in a Laravel project. Laravel 8.0 was released recently, and requires at least Guzzle 7. This library prevents the upgrade by demanding Guzzle 7.x.

I ran the test suite but didn't encounter any errors with this new version, so it should be safe to support both.

Originally created at https://github.com/acmephp/core/pull/10