### PR TITLE
Add option that allows a client to download the alternate certificate link instead of the default one

### DIFF
--- a/src/Core/AcmeClientInterface.php
+++ b/src/Core/AcmeClientInterface.php
@@ -124,4 +124,28 @@ interface AcmeClientInterface
      * @return SecureHttpClient
      */
     public function getHttpClient();
+
+    /**
+     * Request an alternate certificate for the given domain if available.
+     *
+     * This method should be called only if a previous authorization challenge has
+     * been successful for the asked domain.
+     *
+     * WARNING : This method SHOULD NOT BE USED in a web action. It will
+     * wait for the Certificate Authority to validate the certificate and
+     * this operation could be long.
+     *
+     * @param string             $domain  the domain to request a certificate for
+     * @param CertificateRequest $csr     the Certificate Signing Request (informations for the certificate)
+     * @param int                $timeout the timeout period
+     *
+     * @throws AcmeCoreServerException             when the ACME server returns an error HTTP status code
+     *                                             (the exception will be more specific if detail is provided)
+     * @throws AcmeCoreClientException             when an error occured during response parsing
+     * @throws CertificateRequestFailedException   when the certificate request failed
+     * @throws CertificateRequestTimedOutException when the certificate request timed out
+     *
+     * @return CertificateResponse the certificate data to save it somewhere you want
+     */
+    public function requestAlternateCertificate($domain, CertificateRequest $csr, $timeout = 180);
 }

--- a/src/Core/Http/SecureHttpClient.php
+++ b/src/Core/Http/SecureHttpClient.php
@@ -245,7 +245,7 @@ class SecureHttpClient
         $protected = $this->base64Encoder->encode(json_encode($protected, JSON_UNESCAPED_SLASHES));
         if (null === $payload) {
             $payload = '';
-        } elseif ($payload === []) {
+        } elseif ([] === $payload) {
             $payload = $this->base64Encoder->encode('{}');
         } else {
             $payload = $this->base64Encoder->encode(json_encode($payload, JSON_UNESCAPED_SLASHES));
@@ -315,7 +315,7 @@ class SecureHttpClient
      *
      * @return array|string Array of parsed JSON if $returnJson = true, string otherwise
      */
-    public function request($method, $endpoint, array $data = [], $returnJson = true)
+    public function request($method, $endpoint, array $data = [], $returnJson = true, $returnOnlyHeaders = false)
     {
         $call = function () use ($method, $endpoint, $data) {
             $request = $this->createRequest($method, $endpoint, $data);
@@ -332,6 +332,10 @@ class SecureHttpClient
             $request = $call();
         } catch (BadNonceServerException $e) {
             $request = $call();
+        }
+
+        if ($returnOnlyHeaders) {
+            return $this->lastResponse->getHeaders();
         }
 
         $body = \GuzzleHttp\Psr7\copy_to_string($this->lastResponse->getBody());


### PR DESCRIPTION
This will allow a client to request an alternate certificate if the CA provides one, and if not it will download the default one.