### PR TITLE
Support for CSR in PEM added

### DIFF
--- a/src/Core/AcmeClient.php
+++ b/src/Core/AcmeClient.php
@@ -155,7 +155,11 @@ class AcmeClient implements AcmeClientInterface
         if (\in_array($response['status'], ['pending', 'processing', 'ready'])) {
             $humanText = ['-----BEGIN CERTIFICATE REQUEST-----', '-----END CERTIFICATE REQUEST-----'];
 
-            $csrContent = $this->csrSigner->signCertificateRequest($csr);
+            $csrContent = $csr->getCsrPem();
+            if ($csrContent === null) {
+                    $csrContent = $this->csrSigner->signCertificateRequest($csr);
+            }
+            
             $csrContent = trim(str_replace($humanText, '', $csrContent));
             $csrContent = trim($client->getBase64Encoder()->encode(base64_decode($csrContent)));
 

--- a/src/Core/AcmeClient.php
+++ b/src/Core/AcmeClient.php
@@ -332,6 +332,7 @@ class AcmeClient implements AcmeClientInterface
     private function createCertificateResponse(CertificateRequest $csr, string $certificate): CertificateResponse
     {
         $certificatesChain = null;
+        $certificate = str_replace("-----END CERTIFICATE-----\n-----BEGIN CERTIFICATE-----", "-----END CERTIFICATE-----\n\n-----BEGIN CERTIFICATE-----", $certificate);
         foreach (array_reverse(explode("\n\n", $certificate)) as $pem) {
             $certificatesChain = new Certificate($pem, $certificatesChain);
         }

--- a/src/Core/Http/SecureHttpClient.php
+++ b/src/Core/Http/SecureHttpClient.php
@@ -327,7 +327,7 @@ class SecureHttpClient
     private function createRequest($method, $endpoint, $data)
     {
         $request = new Request($method, $endpoint);
-        $request = $request->withHeader('Accept', 'application/json,application/jose+json,pem-certificate-chain,');
+        $request = $request->withHeader('Accept', 'application/json,application/jose+json,application/pem-certificate-chain,');
 
         if ('POST' === $method && \is_array($data)) {
             $request = $request->withHeader('Content-Type', 'application/jose+json');

--- a/src/Core/Http/SecureHttpClient.php
+++ b/src/Core/Http/SecureHttpClient.php
@@ -327,7 +327,7 @@ class SecureHttpClient
     private function createRequest($method, $endpoint, $data)
     {
         $request = new Request($method, $endpoint);
-        $request = $request->withHeader('Accept', 'application/json,application/jose+json,');
+        $request = $request->withHeader('Accept', 'application/json,application/jose+json,pem-certificate-chain,');
 
         if ('POST' === $method && \is_array($data)) {
             $request = $request->withHeader('Content-Type', 'application/jose+json');

--- a/src/Ssl/CertificateRequest.php
+++ b/src/Ssl/CertificateRequest.php
@@ -24,19 +24,37 @@ class CertificateRequest
     /** @var KeyPair */
     private $keyPair;
 
-    public function __construct(DistinguishedName $distinguishedName, KeyPair $keyPair)
+    /** @var CsrPem */
+    private $csrPem;
+
+    public function __construct(DistinguishedName $distinguishedName, KeyPair $keyPair, string $csr_pem = null)
     {
         $this->distinguishedName = $distinguishedName;
         $this->keyPair = $keyPair;
+        $this->csrPem = $csr_pem;
     }
 
-    public function getDistinguishedName(): DistinguishedName
+    /**
+     * @return DistinguishedName
+     */
+    public function getDistinguishedName()
     {
         return $this->distinguishedName;
     }
 
-    public function getKeyPair(): KeyPair
+    /**
+     * @return KeyPair
+     */
+    public function getKeyPair()
     {
         return $this->keyPair;
+    }
+
+    /**
+     * @return CsrPem
+     */
+    public function getCsrPem()
+    {
+        return $this->csrPem;
     }
 }

--- a/src/Ssl/CertificateRequest.php
+++ b/src/Ssl/CertificateRequest.php
@@ -27,11 +27,11 @@ class CertificateRequest
     /** @var CsrPem */
     private $csrPem;
 
-    public function __construct(DistinguishedName $distinguishedName, KeyPair $keyPair, string $csr_pem = null)
+    public function __construct(DistinguishedName $distinguishedName, KeyPair $keyPair, string $csrPem = null)
     {
         $this->distinguishedName = $distinguishedName;
         $this->keyPair = $keyPair;
-        $this->csrPem = $csr_pem;
+        $this->csrPem = $csrPem;
     }
 
     /**


### PR DESCRIPTION
Hi Titouan,

here is my pull request with a small patch that supports getting a certificate based on CSR in PEM format (in my case generated inside HSM).

Review and merge it if thinks it's useful. In my case it is :) HSMs (many of them, small USB tokens) sends CSR in PEM and backend worker based on CSR and the last issued certificate renew a certificate by selecting one of the three supported providers: BuyPASS, Let's Encrypt, and now ZeroSSL.

Best
Chris

P.S.
Another small enhancement should be added to acmephp - a DNS TXT record generation. We do this:

```
$challenges = $order->getAuthorizationChallenges($cn);
...
$hash = hash("sha256", $challenge->getPayload(), true);
$txt = rtrim( strtr(base64_encode( $hash), '+/', '-_'), '=');
```

and now $txt holds a value required by `_acme-challenge.$cn` DNS TXT record. Our system is fully automated, DNS is managed by API (we use and recommend DigitalOcean). Think about adding a function like this:

`$txt = $challenge->getDNSValue();`

or similar. 
