### PR TITLE
Require acmephp/ssl 2.0

### DIFF
--- a/src/Core/composer.json
+++ b/src/Core/composer.json
@@ -31,7 +31,7 @@
         "ext-hash": "*",
         "ext-json": "*",
         "ext-openssl": "*",
-        "acmephp/ssl": "^1.0",
+        "acmephp/ssl": "^2.0",
         "guzzlehttp/guzzle": "^6.0|^7.0",
         "guzzlehttp/psr7": "^1.0",
         "lcobucci/jwt": "^3.3",


### PR DESCRIPTION
Hi,
We try to use core component as a dependency in our project but is impossible to update to 2.0 version.
Right now `acmephp/core` require a previous version `acmephp/ssl`