### PR TITLE
expand compatibility range for lcobucci/jwt to include ^3.3 and ^4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
         "aws/aws-sdk-php": "^3.38",
         "guzzlehttp/guzzle": "^7.2",
         "guzzlehttp/psr7": "^1.0",
-        "lcobucci/jwt": "^3.3",
+        "lcobucci/jwt": "^3.3|^4.0",
         "league/flysystem": "^1.0.19",
         "league/flysystem-memory": "^1.0",
         "league/flysystem-sftp": "^1.0.7",


### PR DESCRIPTION
Widens range for JWT library so downstream projects can update their dependencies while preserving existing functionality of this library.