### PR TITLE
Allow lcobucci/jwt ^4.0 in core package

### DIFF
--- a/src/Core/composer.json
+++ b/src/Core/composer.json
@@ -34,7 +34,7 @@
         "acmephp/ssl": "^2.0",
         "guzzlehttp/guzzle": "^6.0|^7.0",
         "guzzlehttp/psr7": "^1.0",
-        "lcobucci/jwt": "^3.3",
+        "lcobucci/jwt": "^3.3|^4.0",
         "psr/http-message": "^1.0",
         "psr/log": "^1.0",
         "webmozart/assert": "^1.0"


### PR DESCRIPTION
It's required to run acme/core on PHP 8.0. The same condition is in main package https://github.com/acmephp/acmephp/blob/master/composer.json#L49