### PR TITLE
Update Monolog to version 2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,7 @@
         "league/flysystem": "^1.0.19",
         "league/flysystem-memory": "^1.0",
         "league/flysystem-sftp": "^1.0.7",
-        "monolog/monolog": "^1.19",
+        "monolog/monolog": "^1.19|^2.0",
         "padraic/phar-updater": "^1.0",
         "psr/container": "^1.0",
         "psr/http-message": "^1.0",

--- a/src/Cli/Monolog/ConsoleFormatter.php
+++ b/src/Cli/Monolog/ConsoleFormatter.php
@@ -38,7 +38,7 @@ class ConsoleFormatter extends LineFormatter
     /**
      * {@inheritdoc}
      */
-    public function format(array $record)
+    public function format(array $record): string
     {
         if ($record['level'] >= Logger::ERROR) {
             $record['start_tag'] = '<error>';

--- a/src/Cli/Monolog/ConsoleHandler.php
+++ b/src/Cli/Monolog/ConsoleHandler.php
@@ -11,6 +11,7 @@
 
 namespace AcmePhp\Cli\Monolog;
 
+use Monolog\Formatter\FormatterInterface;
 use Monolog\Handler\AbstractProcessingHandler;
 use Monolog\Logger;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -65,7 +66,7 @@ class ConsoleHandler extends AbstractProcessingHandler
     /**
      * {@inheritdoc}
      */
-    public function isHandling(array $record)
+    public function isHandling(array $record): bool
     {
         return $this->updateLevel() && parent::isHandling($record);
     }
@@ -73,7 +74,7 @@ class ConsoleHandler extends AbstractProcessingHandler
     /**
      * {@inheritdoc}
      */
-    public function handle(array $record)
+    public function handle(array $record): bool
     {
         // we have to update the logging level each time because the verbosity of the
         // console output might have changed in the meantime (it is not immutable)
@@ -93,7 +94,7 @@ class ConsoleHandler extends AbstractProcessingHandler
     /**
      * Disables the output.
      */
-    public function close()
+    public function close(): void
     {
         $this->output = null;
 
@@ -103,7 +104,7 @@ class ConsoleHandler extends AbstractProcessingHandler
     /**
      * {@inheritdoc}
      */
-    protected function write(array $record)
+    protected function write(array $record): void
     {
         $this->output->write((string) $record['formatted']);
     }
@@ -111,7 +112,7 @@ class ConsoleHandler extends AbstractProcessingHandler
     /**
      * {@inheritdoc}
      */
-    protected function getDefaultFormatter()
+    protected function getDefaultFormatter(): FormatterInterface
     {
         $formatter = new ConsoleFormatter();
         $formatter->allowInlineLineBreaks();


### PR DESCRIPTION
This should resolve #197

Note: I did get some failures when I ran the tests locally, but they seemed completely unrelated to monolog (e.g. "openssl_pkey_new(): private key length is too short; it needs to be at least 384 bits, not 0") so I'm assuming those were in some way caused by my environment rather than these changes.