### PR TITLE
Test PHP 8 and PHP 8.1 compatability

### DIFF
--- a/.github/workflows/test-build.yaml
+++ b/.github/workflows/test-build.yaml
@@ -81,7 +81,7 @@ jobs:
             - name: Running tests
               run: ./tests/run.sh
 
-    tests-php73-deps-lock-pebble-default:
+    tests-php81-deps-lock-pebble-default:
         runs-on: ubuntu-latest
         steps:
             - uses: shivammathur/setup-php@v2

--- a/.github/workflows/test-build.yaml
+++ b/.github/workflows/test-build.yaml
@@ -64,3 +64,33 @@ jobs:
               run: ./tests/setup.sh
             - name: Running tests
               run: ./tests/run.sh
+
+    tests-php80-deps-high-pebble-eab:
+        runs-on: ubuntu-latest
+        env:
+            PEBBLE_MODE: eab
+        steps:
+            - uses: shivammathur/setup-php@v2
+              with:
+                  php-version: '8.0'
+            - uses: actions/checkout@master
+            - name: Install dependencies
+              run: composer update --no-interaction --no-progress --ansi --prefer-stable
+            - name: Preparing tests
+              run: ./tests/setup.sh
+            - name: Running tests
+              run: ./tests/run.sh
+
+    tests-php73-deps-lock-pebble-default:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: shivammathur/setup-php@v2
+              with:
+                  php-version: '8.1'
+            - uses: actions/checkout@master
+            - name: Install dependencies
+              run: composer install
+            - name: Preparing tests
+              run: ./tests/setup.sh
+            - name: Running tests
+              run: ./tests/run.sh              


### PR DESCRIPTION
I followed the existing pattern in the GitHub workflow file, and configured it to test PHP 8.0  and PHP 8.1.

This way we can see what needs to happen before we can launch PHP 8.x support.