### PR TITLE
Add Core\AcmeClient::reloadOrder method

### DIFF
--- a/src/Core/AcmeClient.php
+++ b/src/Core/AcmeClient.php
@@ -140,7 +140,32 @@ class AcmeClient implements AcmeClientInterface
             }
         }
 
-        return new CertificateOrder($authorizationsChallenges, $orderEndpoint);
+        return new CertificateOrder($authorizationsChallenges, $orderEndpoint, $response['status']);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function reloadOrder(CertificateOrder $order): CertificateOrder
+    {
+        $client = $this->getHttpClient();
+        $orderEndpoint = $order->getOrderEndpoint();
+        $response = $client->request('POST', $orderEndpoint, $client->signKidPayload($orderEndpoint, $this->getResourceAccount(), null));
+
+        if (!isset($response['authorizations']) || !$response['authorizations']) {
+            throw new ChallengeNotSupportedException();
+        }
+
+        $authorizationsChallenges = [];
+        foreach ($response['authorizations'] as $authorizationEndpoint) {
+            $authorizationsResponse = $client->request('POST', $authorizationEndpoint, $client->signKidPayload($authorizationEndpoint, $this->getResourceAccount(), null));
+            $domain = (empty($authorizationsResponse['wildcard']) ? '' : '*.').$authorizationsResponse['identifier']['value'];
+            foreach ($authorizationsResponse['challenges'] as $challenge) {
+                $authorizationsChallenges[$domain][] = $this->createAuthorizationChallenge($authorizationsResponse['identifier']['value'], $challenge);
+            }
+        }
+
+        return new CertificateOrder($authorizationsChallenges, $orderEndpoint, $response['status']);
     }
 
     /**

--- a/src/Core/AcmeClientInterface.php
+++ b/src/Core/AcmeClientInterface.php
@@ -67,6 +67,11 @@ interface AcmeClientInterface
     public function requestOrder(array $domains): CertificateOrder;
 
     /**
+     * Request the current status of a certificate order.
+     */
+    public function reloadOrder(CertificateOrder $order): CertificateOrder;
+
+    /**
      * Request a certificate for the given domain.
      *
      * This method should be called only if a previous authorization challenge has

--- a/src/Core/Protocol/CertificateOrder.php
+++ b/src/Core/Protocol/CertificateOrder.php
@@ -26,7 +26,10 @@ class CertificateOrder
     /** @var string */
     private $orderEndpoint;
 
-    public function __construct(array $authorizationsChallenges, string $orderEndpoint = null)
+    /** @var string */
+    private $status;
+
+    public function __construct(array $authorizationsChallenges, string $orderEndpoint = null, string $status = null)
     {
         foreach ($authorizationsChallenges as &$authorizationChallenges) {
             foreach ($authorizationChallenges as &$authorizationChallenge) {
@@ -38,6 +41,7 @@ class CertificateOrder
 
         $this->authorizationsChallenges = $authorizationsChallenges;
         $this->orderEndpoint = $orderEndpoint;
+        $this->status = $status;
     }
 
     public function toArray(): array
@@ -45,6 +49,7 @@ class CertificateOrder
         return [
             'authorizationsChallenges' => $this->getAuthorizationsChallenges(),
             'orderEndpoint' => $this->getOrderEndpoint(),
+            'status' => $this->getStatus(),
         ];
     }
 
@@ -76,5 +81,10 @@ class CertificateOrder
     public function getOrderEndpoint(): string
     {
         return $this->orderEndpoint;
+    }
+
+    public function getStatus(): string
+    {
+        return $this->status;
     }
 }

--- a/tests/Core/AcmeClientTest.php
+++ b/tests/Core/AcmeClientTest.php
@@ -76,6 +76,7 @@ class AcmeClientTest extends AbstractFunctionnalTest
          * Ask for domain challenge
          */
         $order = $client->requestOrder(['acmephp.com']);
+        $this->assertEquals('pending', $order->getStatus());
         $challenges = $order->getAuthorizationChallenges('acmephp.com');
         foreach ($challenges as $challenge) {
             if ('http-01' === $challenge->getType()) {
@@ -99,6 +100,15 @@ class AcmeClientTest extends AbstractFunctionnalTest
         } finally {
             $this->cleanChallenge($challenge->getToken());
         }
+
+        /**
+         * Reload order, check if challenge was completed.
+         */
+        $updatedOrder = $client->reloadOrder($order);
+        $this->assertEquals('ready', $updatedOrder->getStatus());
+        $this->assertCount(1, $updatedOrder->getAuthorizationChallenges('acmephp.com'));
+        $validatedChallenge = $updatedOrder->getAuthorizationChallenges('acmephp.com')[0];
+        $this->assertEquals('valid', $validatedChallenge->getStatus());
 
         /*
          * Request certificate


### PR DESCRIPTION
The reloadOrder method refreshes CertificateOrder information from the CA.
This is useful if the CA returned a server error, and you need to retrieve what has been done.
Also add the order status property to the CertificateOrder object to check this.