### PR TITLE
Fix tests on PHP 8.0/8.1

### DIFF
--- a/.github/workflows/test-build.yaml
+++ b/.github/workflows/test-build.yaml
@@ -64,3 +64,20 @@ jobs:
               run: ./tests/setup.sh
             - name: Running tests
               run: ./tests/run.sh
+
+    tests-php80-deps-high-pebble-eab:
+        runs-on: ubuntu-latest
+        env:
+            PEBBLE_MODE: eab
+        steps:
+            - uses: shivammathur/setup-php@v2
+              with:
+                  php-version: '8.0'
+            - uses: actions/checkout@master
+            - name: Install dependencies
+              run: composer update --no-interaction --no-progress --ansi --prefer-stable
+            - name: Preparing tests
+              run: ./tests/setup.sh
+            - name: Running tests
+              run: ./tests/run.sh
+

--- a/.github/workflows/test-build.yaml
+++ b/.github/workflows/test-build.yaml
@@ -81,3 +81,19 @@ jobs:
             - name: Running tests
               run: ./tests/run.sh
 
+    tests-php81-deps-high-pebble-eab:
+        runs-on: ubuntu-latest
+        env:
+            PEBBLE_MODE: eab
+        steps:
+            - uses: shivammathur/setup-php@v2
+              with:
+                  php-version: '8.1'
+            - uses: actions/checkout@master
+            - name: Install dependencies
+              run: composer update --no-interaction --no-progress --ansi --prefer-stable
+            - name: Preparing tests
+              run: ./tests/setup.sh
+            - name: Running tests
+              run: ./tests/run.sh
+

--- a/.github/workflows/test-build.yaml
+++ b/.github/workflows/test-build.yaml
@@ -81,19 +81,3 @@ jobs:
             - name: Running tests
               run: ./tests/run.sh
 
-    tests-php81-deps-high-pebble-eab:
-        runs-on: ubuntu-latest
-        env:
-            PEBBLE_MODE: eab
-        steps:
-            - uses: shivammathur/setup-php@v2
-              with:
-                  php-version: '8.1'
-            - uses: actions/checkout@master
-            - name: Install dependencies
-              run: composer update --no-interaction --no-progress --ansi --prefer-stable
-            - name: Preparing tests
-              run: ./tests/setup.sh
-            - name: Running tests
-              run: ./tests/run.sh
-

--- a/src/Ssl/Key.php
+++ b/src/Ssl/Key.php
@@ -47,7 +47,7 @@ abstract class Key
     }
 
     /**
-     * @return resource
+     * @return resource|\OpenSSLAsymmetricKey
      */
     abstract public function getResource();
 }

--- a/tests/Ssl/AssertsOpenSslResource.php
+++ b/tests/Ssl/AssertsOpenSslResource.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Acme PHP project.
+ *
+ * (c) Titouan Galopin <galopintitouan@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\AcmePhp\Ssl;
+
+use PHPUnit\Framework\Assert;
+
+trait AssertsOpenSslResource
+{
+    /**
+     * Asserts that the provided "resource" is an OpenSSL Assymetric Key.
+     *
+     * On PHP 8+, OpenSSL works with objects. On PHP <8 OpenSSL works with resources.
+     *
+     * @param resource|\OpenSSLAsymmetricKey $resource
+     */
+    public function assertIsOpenSslAsymmetricKey($resource)
+    {
+        if (PHP_MAJOR_VERSION >= 8) {
+            Assert::assertInstanceOf(\OpenSSLAsymmetricKey::class, $resource);
+        } else {
+            Assert::assertIsResource($resource);
+        }
+    }
+}

--- a/tests/Ssl/CertificateTest.php
+++ b/tests/Ssl/CertificateTest.php
@@ -17,6 +17,8 @@ use PHPUnit\Framework\TestCase;
 
 class CertificateTest extends TestCase
 {
+    use AssertsOpenSslResource;
+
     public function test_getPublicKey_returns_a_PublicKey()
     {
         $certificate = new Certificate(
@@ -102,6 +104,6 @@ oVyIb1lpwK0r0vN9y8ns80MP3HtjPYtARWJ9z9P4N+guHZdnbw==
 
         $resource = $certificate->getPublicKeyResource();
 
-        $this->assertIsResource($resource);
+        $this->assertIsOpenSslAsymmetricKey($resource);
     }
 }

--- a/tests/Ssl/Generator/KeyPairGeneratorTest.php
+++ b/tests/Ssl/Generator/KeyPairGeneratorTest.php
@@ -18,9 +18,12 @@ use AcmePhp\Ssl\Generator\KeyPairGenerator;
 use AcmePhp\Ssl\Generator\RsaKey\RsaKeyOption;
 use AcmePhp\Ssl\KeyPair;
 use PHPUnit\Framework\TestCase;
+use Tests\AcmePhp\Ssl\AssertsOpenSslResource;
 
 class KeyPairGeneratorTest extends TestCase
 {
+    use AssertsOpenSslResource;
+
     /** @var KeyPairGenerator */
     private $service;
 
@@ -38,8 +41,8 @@ class KeyPairGeneratorTest extends TestCase
         $this->assertInstanceOf(KeyPair::class, $result);
         $this->assertStringContainsString('-----BEGIN PUBLIC KEY-----', $result->getPublicKey()->getPEM());
         $this->assertStringContainsString('-----BEGIN PRIVATE KEY-----', $result->getPrivateKey()->getPEM());
-        $this->assertIsResource($result->getPublicKey()->getResource());
-        $this->assertIsResource($result->getPrivateKey()->getResource());
+        $this->assertIsOpenSslAsymmetricKey($result->getPublicKey()->getResource());
+        $this->assertIsOpenSslAsymmetricKey($result->getPrivateKey()->getResource());
 
         $details = openssl_pkey_get_details($result->getPrivateKey()->getResource());
         $this->assertEquals(1024, $details['bits']);
@@ -56,8 +59,8 @@ class KeyPairGeneratorTest extends TestCase
         $this->assertInstanceOf(KeyPair::class, $result);
         $this->assertStringContainsString('-----BEGIN PUBLIC KEY-----', $result->getPublicKey()->getPEM());
         $this->assertStringContainsString('-----BEGIN PRIVATE KEY-----', $result->getPrivateKey()->getPEM());
-        $this->assertIsResource($result->getPublicKey()->getResource());
-        $this->assertIsResource($result->getPrivateKey()->getResource());
+        $this->assertIsOpenSslAsymmetricKey($result->getPublicKey()->getResource());
+        $this->assertIsOpenSslAsymmetricKey($result->getPrivateKey()->getResource());
 
         $details = openssl_pkey_get_details($result->getPrivateKey()->getResource());
         $this->assertArrayHasKey('dh', $details);
@@ -70,8 +73,8 @@ class KeyPairGeneratorTest extends TestCase
         $this->assertInstanceOf(KeyPair::class, $result);
         $this->assertStringContainsString('-----BEGIN PUBLIC KEY-----', $result->getPublicKey()->getPEM());
         $this->assertStringContainsString('-----BEGIN PRIVATE KEY-----', $result->getPrivateKey()->getPEM());
-        $this->assertIsResource($result->getPublicKey()->getResource());
-        $this->assertIsResource($result->getPrivateKey()->getResource());
+        $this->assertIsOpenSslAsymmetricKey($result->getPublicKey()->getResource());
+        $this->assertIsOpenSslAsymmetricKey($result->getPrivateKey()->getResource());
 
         $details = openssl_pkey_get_details($result->getPrivateKey()->getResource());
         $this->assertEquals(1024, $details['bits']);
@@ -88,8 +91,8 @@ class KeyPairGeneratorTest extends TestCase
         $this->assertInstanceOf(KeyPair::class, $result);
         $this->assertStringContainsString('-----BEGIN PUBLIC KEY-----', $result->getPublicKey()->getPEM());
         $this->assertStringContainsString('-----BEGIN EC PRIVATE KEY-----', $result->getPrivateKey()->getPEM());
-        $this->assertIsResource($result->getPublicKey()->getResource());
-        $this->assertIsResource($result->getPrivateKey()->getResource());
+        $this->assertIsOpenSslAsymmetricKey($result->getPublicKey()->getResource());
+        $this->assertIsOpenSslAsymmetricKey($result->getPrivateKey()->getResource());
 
         $details = openssl_pkey_get_details($result->getPrivateKey()->getResource());
         $this->assertEquals(112, $details['bits']);

--- a/tests/Ssl/Generator/KeyPairGeneratorTest.php
+++ b/tests/Ssl/Generator/KeyPairGeneratorTest.php
@@ -39,14 +39,14 @@ class KeyPairGeneratorTest extends TestCase
         $result = $this->service->generateKeyPair(new RsaKeyOption(1024));
 
         $this->assertInstanceOf(KeyPair::class, $result);
-        $this->assertStringContainsString('-----BEGIN PUBLIC KEY-----', $result->getPublicKey()->getPEM());
-        $this->assertStringContainsString('-----BEGIN PRIVATE KEY-----', $result->getPrivateKey()->getPEM());
         $this->assertIsOpenSslAsymmetricKey($result->getPublicKey()->getResource());
         $this->assertIsOpenSslAsymmetricKey($result->getPrivateKey()->getResource());
 
         $details = openssl_pkey_get_details($result->getPrivateKey()->getResource());
         $this->assertEquals(1024, $details['bits']);
         $this->assertArrayHasKey('rsa', $details);
+
+        $this->assertEquals($details['key'], $result->getPublicKey()->getPEM());
     }
 
     public function test_generateKeyPair_generate_random_instance_of_KeyPair_using_DH()
@@ -57,13 +57,13 @@ class KeyPairGeneratorTest extends TestCase
         ));
 
         $this->assertInstanceOf(KeyPair::class, $result);
-        $this->assertStringContainsString('-----BEGIN PUBLIC KEY-----', $result->getPublicKey()->getPEM());
-        $this->assertStringContainsString('-----BEGIN PRIVATE KEY-----', $result->getPrivateKey()->getPEM());
         $this->assertIsOpenSslAsymmetricKey($result->getPublicKey()->getResource());
         $this->assertIsOpenSslAsymmetricKey($result->getPrivateKey()->getResource());
 
         $details = openssl_pkey_get_details($result->getPrivateKey()->getResource());
         $this->assertArrayHasKey('dh', $details);
+
+        $this->assertEquals($details['key'], $result->getPublicKey()->getPEM());
     }
 
     public function test_generateKeyPair_generate_random_instance_of_KeyPair_using_DSA()
@@ -71,14 +71,14 @@ class KeyPairGeneratorTest extends TestCase
         $result = $this->service->generateKeyPair(new DsaKeyOption(1024));
 
         $this->assertInstanceOf(KeyPair::class, $result);
-        $this->assertStringContainsString('-----BEGIN PUBLIC KEY-----', $result->getPublicKey()->getPEM());
-        $this->assertStringContainsString('-----BEGIN PRIVATE KEY-----', $result->getPrivateKey()->getPEM());
         $this->assertIsOpenSslAsymmetricKey($result->getPublicKey()->getResource());
         $this->assertIsOpenSslAsymmetricKey($result->getPrivateKey()->getResource());
 
         $details = openssl_pkey_get_details($result->getPrivateKey()->getResource());
         $this->assertEquals(1024, $details['bits']);
         $this->assertArrayHasKey('dsa', $details);
+
+        $this->assertEquals($details['key'], $result->getPublicKey()->getPEM());
     }
 
     /**
@@ -89,8 +89,6 @@ class KeyPairGeneratorTest extends TestCase
         $result = $this->service->generateKeyPair(new EcKeyOption('secp112r1'));
 
         $this->assertInstanceOf(KeyPair::class, $result);
-        $this->assertStringContainsString('-----BEGIN PUBLIC KEY-----', $result->getPublicKey()->getPEM());
-        $this->assertStringContainsString('-----BEGIN EC PRIVATE KEY-----', $result->getPrivateKey()->getPEM());
         $this->assertIsOpenSslAsymmetricKey($result->getPublicKey()->getResource());
         $this->assertIsOpenSslAsymmetricKey($result->getPrivateKey()->getResource());
 
@@ -98,5 +96,7 @@ class KeyPairGeneratorTest extends TestCase
         $this->assertEquals(112, $details['bits']);
         $this->assertArrayHasKey('ec', $details);
         $this->assertEquals('secp112r1', $details['ec']['curve_name']);
+
+        $this->assertEquals($details['key'], $result->getPublicKey()->getPEM());
     }
 }


### PR DESCRIPTION
The current tests don't work on PHP 8.0 because OpenSSL changed from using `resource`s for it's data structures to using objects.

So I added a function that checks the right type for the right PHP versions.