### PR TITLE
Remove unused swiftmailer dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -55,7 +55,6 @@
         "psr/container": "^1.0",
         "psr/http-message": "^1.0",
         "psr/log": "^1.0",
-        "swiftmailer/swiftmailer": "^5.4|^6.0",
         "symfony/config": "^5.0|^6.0",
         "symfony/console": "^5.0|^6.0",
         "symfony/dependency-injection": "^5.0|^6.0",


### PR DESCRIPTION
I can't see any usages of `swiftmailer/swiftmailer`.
Therefore, I guess the dependency can be safely removed.