### PR TITLE
Allow for newer dependencies and fix a couple of issues in AcmePhp\Core.

### DIFF
--- a/src/Core/AcmeClient.php
+++ b/src/Core/AcmeClient.php
@@ -327,9 +327,13 @@ class AcmeClient implements AcmeClientInterface
 
     private function createCertificateResponse(CertificateRequest $csr, string $certificate): CertificateResponse
     {
+        $certificateHeader = '-----BEGIN CERTIFICATE-----';
         $certificatesChain = null;
-        foreach (array_reverse(explode("\n\n", $certificate)) as $pem) {
-            $certificatesChain = new Certificate($pem, $certificatesChain);
+
+        foreach (array_reverse(explode($certificateHeader, $certificate)) as $pem) {
+            if (\trim($pem) !== '') {
+                $certificatesChain = new Certificate($certificateHeader . $pem, $certificatesChain);
+            }
         }
 
         return new CertificateResponse($csr, $certificatesChain);

--- a/src/Core/AcmeClient.php
+++ b/src/Core/AcmeClient.php
@@ -331,8 +331,8 @@ class AcmeClient implements AcmeClientInterface
         $certificatesChain = null;
 
         foreach (array_reverse(explode($certificateHeader, $certificate)) as $pem) {
-            if (\trim($pem) !== '') {
-                $certificatesChain = new Certificate($certificateHeader . $pem, $certificatesChain);
+            if ('' !== \trim($pem)) {
+                $certificatesChain = new Certificate($certificateHeader.$pem, $certificatesChain);
             }
         }
 

--- a/src/Core/Http/SecureHttpClient.php
+++ b/src/Core/Http/SecureHttpClient.php
@@ -211,7 +211,7 @@ class SecureHttpClient
 
             $data = JsonDecoder::decode($body, true);
         } catch (\InvalidArgumentException $exception) {
-            throw new ExpectedJsonException(sprintf('ACME client excepted valid JSON as a response to request "%s %s" (given: "%s")', $method, $endpoint, ServerErrorHandler::getResponseBodySummary($response)), $exception);
+            throw new ExpectedJsonException(sprintf('ACME client expected valid JSON as a response to request "%s %s" (given: "%s")', $method, $endpoint, ServerErrorHandler::getResponseBodySummary($response)), $exception);
         }
 
         return $data;

--- a/src/Core/Http/ServerErrorHandler.php
+++ b/src/Core/Http/ServerErrorHandler.php
@@ -33,6 +33,7 @@ use AcmePhp\Core\Exception\Server\UnsupportedIdentifierServerException;
 use AcmePhp\Core\Exception\Server\UserActionRequiredServerException;
 use AcmePhp\Core\Util\JsonDecoder;
 use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Psr7\Utils;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 
@@ -80,7 +81,7 @@ class ServerErrorHandler
             return RequestException::getResponseBodySummary($response);
         }
 
-        $body = \GuzzleHttp\Psr7\copy_to_string($response->getBody());
+        $body = Utils::copyToString($response->getBody());
 
         if (\strlen($body) > 120) {
             return substr($body, 0, 120).' (truncated...)';
@@ -94,7 +95,7 @@ class ServerErrorHandler
         ResponseInterface $response,
         \Exception $previous = null
     ): AcmeCoreServerException {
-        $body = \GuzzleHttp\Psr7\copy_to_string($response->getBody());
+        $body = Utils::copyToString($response->getBody());
 
         try {
             $data = JsonDecoder::decode($body, true);

--- a/src/Core/Protocol/CertificateOrder.php
+++ b/src/Core/Protocol/CertificateOrder.php
@@ -42,8 +42,20 @@ class CertificateOrder
 
     public function toArray(): array
     {
+        $authorizationsChallenges = array_map(
+            function ($challenges): array {
+                return array_map(
+                    function ($challenge): array {
+                        return $challenge->toArray();
+                    },
+                    $challenges
+                );
+            },
+            $this->getAuthorizationsChallenges()
+        );
+
         return [
-            'authorizationsChallenges' => $this->getAuthorizationsChallenges(),
+            'authorizationsChallenges' => $authorizationsChallenges,
             'orderEndpoint' => $this->getOrderEndpoint(),
         ];
     }

--- a/src/Core/composer.json
+++ b/src/Core/composer.json
@@ -33,10 +33,10 @@
         "ext-openssl": "*",
         "acmephp/ssl": "^2.0",
         "guzzlehttp/guzzle": "^6.0|^7.0",
-        "guzzlehttp/psr7": "^1.0",
+        "guzzlehttp/psr7": "^1.7|^2.1",
         "lcobucci/jwt": "^3.3|^4.0",
         "psr/http-message": "^1.0",
-        "psr/log": "^1.0",
+        "psr/log": "^1.0|^2.0|^3.0",
         "webmozart/assert": "^1.0"
     },
     "autoload": {


### PR DESCRIPTION
- Noticed that `AcmeClient` was not properly breaking apart valid certificate chains.
- Allow users of Core to require newer psr/log and guzzlehttp/psr7 versions.
- Fix an issue with CertificateOrders where the embedded authorization challenges were not also being converted to arrays in `toArray`.
- Fix an error message typo.