### PR TITLE
change private account to public account

### DIFF
--- a/src/Core/AcmeClient.php
+++ b/src/Core/AcmeClient.php
@@ -66,7 +66,7 @@ class AcmeClient implements AcmeClientInterface
     /**
      * @var string
      */
-    private $account;
+    public $account;
 
     public function __construct(SecureHttpClient $httpClient, string $directoryUrl, CertificateRequestSigner $csrSigner = null)
     {


### PR DESCRIPTION
Public 'account' can be set by developers instead of registering every time