### PR TITLE
fix: allow psr/http-message v2

### DIFF
--- a/src/Core/composer.json
+++ b/src/Core/composer.json
@@ -35,7 +35,7 @@
         "guzzlehttp/guzzle": "^6.0|^7.0",
         "guzzlehttp/psr7": "^1.7|^2.1",
         "lcobucci/jwt": "^3.3|^4.0",
-        "psr/http-message": "^1.0",
+        "psr/http-message": "^1 || ^2",
         "psr/log": "^1.0|^2.0|^3.0",
         "webmozart/assert": "^1.0"
     },


### PR DESCRIPTION
This changes relaxes the version constraint on `psr/http-message` in core.
The core only uses the interface(s) for type hints but doesn't actually interact with any of the instances.

Untested, do not merge yet.