### PR TITLE
Chain previous into exceptions thrown from catch blocks

### DIFF
--- a/src/Core/AcmeClient.php
+++ b/src/Core/AcmeClient.php
@@ -226,7 +226,7 @@ class AcmeClient implements AcmeClientInterface
         try {
             return $order->getAuthorizationChallenges($domain);
         } catch (AcmeCoreClientException $e) {
-            throw new ChallengeNotSupportedException();
+            throw new ChallengeNotSupportedException($e);
         }
     }
 

--- a/src/Core/Challenge/Dns/LibDnsResolver.php
+++ b/src/Core/Challenge/Dns/LibDnsResolver.php
@@ -97,7 +97,7 @@ class LibDnsResolver implements DnsResolverInterface
             try {
                 $response = $this->request($domain, ResourceTypes::TXT, $ipNameServer[0]);
             } catch (\Exception $e) {
-                throw new AcmeDnsResolutionException(sprintf('Unable to find domain %s on nameserver %s', $domain, $nameServer));
+                throw new AcmeDnsResolutionException(sprintf('Unable to find domain %s on nameserver %s', $domain, $nameServer), $e);
             }
             $entries = [];
             foreach ($response->getAnswerRecords() as $record) {


### PR DESCRIPTION
Following on from the capitalisation of domain names issue here: https://github.com/acmephp/acmephp/issues/280 where this issue was mentioned.

This PR fixes a couple of places where the $previous exception was not being chained into new exceptions inside catch blocks which currently obscures the full stack trace which should point to the original source of the error.