### PR TITLE
Pull pebble from ghcr.io

### DIFF
--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -10,8 +10,8 @@ docker run -d --name acme_sftp -p 8022:22 atmoz/sftp acmephp:acmephp:::share
 # pebble
 MODE=${PEBBLE_MODE:-default}
 
-docker run -d --name acme_server --net host letsencrypt/pebble-challtestsrv pebble-challtestsrv -defaultIPv6 "" -defaultIPv4 127.0.0.1
-docker run -d --name acme_pebble --net host -e PEBBLE_VA_NOSLEEP=1 -e PEBBLE_WFE_NONCEREJECT=0 -e PEBBLE_ALTERNATE_ROOTS=1 -v $(pwd)/tests/Fixtures/pebble-config-$MODE.json:/test/config/pebble-config.json letsencrypt/pebble pebble -dnsserver 127.0.0.1:8053
+docker run -d --name acme_server --net host ghcr.io/letsencrypt/pebble-challtestsrv pebble-challtestsrv -defaultIPv6 "" -defaultIPv4 127.0.0.1
+docker run -d --name acme_pebble --net host -e PEBBLE_VA_NOSLEEP=1 -e PEBBLE_WFE_NONCEREJECT=0 -e PEBBLE_ALTERNATE_ROOTS=1 -v $(pwd)/tests/Fixtures/pebble-config-$MODE.json:/test/config/pebble-config.json ghcr.io/letsencrypt/pebble pebble -dnsserver 127.0.0.1:8053
 
 # Wait for boot to be completed
 docker run --rm --net host martin/wait -c localhost:14000,localhost:8022,localhost:8053,localhost:5002 -t 120


### PR DESCRIPTION
Let's Encrypt is moving Pebble to ghcr.io instead of dockerhub.

New versions of Pebble will only be available on ghcr.io
