### PR TITLE
add header accept application/pem-certificate-chain

### DIFF
--- a/src/Core/Http/SecureHttpClient.php
+++ b/src/Core/Http/SecureHttpClient.php
@@ -329,7 +329,7 @@ class SecureHttpClient
         $request = new Request($method, $endpoint);
 
         if ($acceptJson) {
-            $request = $request->withHeader('Accept', 'application/json,application/jose+json,');
+            $request = $request->withHeader('Accept', 'application/json,application/jose+json,application/pem-certificate-chain,');
         } else {
             $request = $request->withHeader('Accept', '*/*');
         }


### PR DESCRIPTION
to be able to support D-Trust as a CA and use their acme endpoint, it's required to add an accept header for 'application/pem-certificate-chain'

this change is also requested in the [MR](https://github.com/acmephp/acmephp/pull/225), but with additional changes, which i don't need at the moment ;-)